### PR TITLE
Баг при пробелах в пути

### DIFF
--- a/VkNet/VkNet.csproj
+++ b/VkNet/VkNet.csproj
@@ -260,8 +260,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">$(TargetDir)Injector.exe</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">mono $(TargetDir)Injector.exe</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">"$(TargetDir)Injector.exe"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">mono "$(TargetDir)Injector.exe"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Добавить скобки, иначе Injector.exe не запустится, если в пути пробелы.
The command "C:\Users\simple\Documents\Visual Studio 2015\Projects\VkNews\vkNet\Release\Injector.exe" exited with code 9009.