### PR TITLE
Исправление вложения поста типа Page

### DIFF
--- a/VkNet/Model/Attachments/Page.cs
+++ b/VkNet/Model/Attachments/Page.cs
@@ -117,7 +117,7 @@ namespace VkNet.Model.Attachments
 
 		public override string ToString()
 		{
-			return string.Format("page{0}_{1}", GroupId, Id);
+			return string.Format("page-{0}_{1}", GroupId, Id);
 		}
 
         #endregion


### PR DESCRIPTION
Изменен формат ссылки, иначе если публиковать пост с таким вложением, то он не опубликовался бы, из-за неправильной ссылки на страницу.