### PR TITLE
Place.Id и Place.ShowMap сделаны Nullable

### DIFF
--- a/VkNet/Model/Place.cs
+++ b/VkNet/Model/Place.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Идентификатор места.
         /// </summary>
-        public long Id { get; set; }
+        public long Id? { get; set; }
 
         /// <summary>
         /// Название места.
@@ -55,7 +55,7 @@
         /// <summary>
         /// Данный параметр указывается, если местоположение является прикреплённой картой.
         /// </summary>
-        public bool ShowMap { get; set; }
+        public bool ShowMap? { get; set; }
 
         #region Поля, установленные экспериментально
 


### PR DESCRIPTION
## Список изменений
- свойства `Place.Id` и `Place.ShowMap` теперь могут быть `null` ([issue #265](https://github.com/vknet/vk/issues/265))

При парсинге сообщений сервер ВК может вернуть информацию о месте `message.geo.place`, которая не содержит полей `id` и `showmap`.