### PR TITLE
Исправления авторизации на UWP

### DIFF
--- a/VkNet.UWP/Utils/Cookies.cs
+++ b/VkNet.UWP/Utils/Cookies.cs
@@ -46,7 +46,7 @@
         {
             var table = (IDictionary)Container.GetType()
                                             .GetRuntimeFields()
-                                            .FirstOrDefault(x => x.Name == "m_domainTable")
+                                            .FirstOrDefault(x => x.Name == "m_domainTable" || x.Name == "_domainTable")
                                             .GetValue(Container);
             var keys = table.Keys.OfType<string>().ToList();
             foreach (var key in table.Keys.OfType<string>().ToList())

--- a/VkNet.UWP/Utils/WebCall.cs
+++ b/VkNet.UWP/Utils/WebCall.cs
@@ -183,7 +183,7 @@ namespace VkNet.Utils
                 var encoding = Encoding.UTF8;
                 _result.SaveResponse(response.RequestMessage.RequestUri, stream, encoding);
 
-                var cookies = new CookieContainer();
+                var cookies = _result.Cookies.Container;
 
                 _result.SaveCookies(cookies.GetCookies(uri));
                 return response.StatusCode == HttpStatusCode.Redirect

--- a/VkNet.UWP/Utils/WebForm.cs
+++ b/VkNet.UWP/Utils/WebForm.cs
@@ -100,14 +100,13 @@ namespace VkNet.Utils
 				throw new InvalidOperationException("Field name not set!");
 			}
 
-			var encodedValue = Uri.EscapeDataString(value);
 			if (_inputs.ContainsKey(_lastName))
 			{
-				_inputs[_lastName] = encodedValue;
+				_inputs[_lastName] = value;
 			}
 			else
 			{
-				_inputs.Add(_lastName, encodedValue);
+				_inputs.Add(_lastName, value);
 			}
 
 			return this;


### PR DESCRIPTION
## Список изменений
- Исправления работы с куками: при чтении кук из ответа используется тот же контейнер кук, что и при запросе; Добавлен новый ключ _domainTable.
- Внесены корректировки в значения, отправляемые веб формой для авторизации. Значения передаются как есть без приведении к Url строке.

