### PR TITLE
Исправлен метод SaveWallPhoto из pull-request #379

### DIFF
--- a/VkNet.UWP/Categories/PhotoCategory.cs
+++ b/VkNet.UWP/Categories/PhotoCategory.cs
@@ -250,7 +250,7 @@
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/photos.saveWallPhoto" />.
 		/// </remarks>
-		public ReadOnlyCollection<Photo> SaveWallPhoto(string response, ulong? userId = null, ulong? groupId = null, string? caption = null)
+		public ReadOnlyCollection<Photo> SaveWallPhoto(string response, ulong? userId = null, ulong? groupId = null, string caption = null)
 		{
 			var responseJson = JObject.Parse(response);
 			var server = responseJson["server"].ToString();


### PR DESCRIPTION
Тип string нельзя использовать в структуре Nullable<T>, так как ссылочный тип string допускают значение NULL намеренно. (pull-request #379)