### PR TITLE
Модифицирована GetApiUrlAndAddToken

### DIFF
--- a/VkNet.UWP/VkApi.cs
+++ b/VkNet.UWP/VkApi.cs
@@ -314,7 +314,9 @@ namespace VkNet
 		{
             //подключение браузера через прокси 
             if (@params.Host != null)
+            {
                 Browser.Proxy = WebProxy.GetProxy(@params.Host, @params.Port, @params.ProxyLogin, @params.ProxyPassword);
+            }
 
             //если токен не задан - обычная авторизация
             if (@params.AccessToken == null)
@@ -642,7 +644,7 @@ namespace VkNet
 		{
             if (!skipAuthorization)
             {
-                parameters.Add("access_token", AccessToken);
+                parameters["access_token"] = AccessToken;
             }
 
 			return $"https://api.vk.com/method/{methodName}?{string.Join("&", parameters.Select(x => $"{x.Key}={x.Value}"))}";


### PR DESCRIPTION
Модифицирована функция GetApiUrlAndAddToken

В функции GetApiUrlAndAddToken при добавлении к коллекцию параметров параметра access_token не проводилась проверка на его существование в коллекции. Это в определенных ситуациях может вызывать исключение "System.ArgumentException: Элемент с тем же ключом уже был добавлен".
 
Например пользователь сформировал коллекцию с параметрами, вызвал метод invoke, передал в него по ссылке свою коллекцию параметров. При первом вызове в его коллекцию добавился параметр access_token. Затем происходит запрос капчи, пользователь распознает ее, добавляет в свою коллекцию captcha_sid и captcha_key, повторно вызывает метод invoke и получает исключение при попытке добавить  access_token в коллекцию, так как он там уже есть.

Предлагаю перед добавлением элементов в коллекцию проверять их наличие там функцией ContainsKey, или использовать упрощенную запись, как в предлагаемом мной варианте.

Так же исправлено замечание из прошлого пулреквеста.
