### PR TITLE
Модифицирован метод EditManager

### DIFF
--- a/VkNet.UWP/Categories/Obsolete/GroupsCategory.Obsolete.cs
+++ b/VkNet.UWP/Categories/Obsolete/GroupsCategory.Obsolete.cs
@@ -33,7 +33,8 @@ namespace VkNet.Categories
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.get" />.
 		/// </remarks>
-		[Pure]		[Obsolete("Данный метод устарел. Используйте Get(GroupsGetParams @params)")]
+		[Pure]
+		[Obsolete("Данный метод устарел. Используйте Get(GroupsGetParams @params)")]
 		public ReadOnlyCollection<Group> Get(long uid, bool extended = false, GroupsFilters filters = null, GroupsFields fields = null, uint offset = 0, uint count = 1000)
 		{
 			VkErrors.ThrowIfNumberIsNegative(() => uid);
@@ -191,7 +192,8 @@ namespace VkNet.Categories
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.isMember"/>.
 		/// </remarks>
-		[Pure]		[Obsolete("Данный метод устарел. Используйте IsMember(string groupId,Join long? userId, IEnumerable<string> userIds, bool? extended)")]
+		[Pure]
+		[Obsolete("Данный метод устарел. Используйте IsMember(string groupId,Join long? userId, IEnumerable<string> userIds, bool? extended)")]
 		public bool IsMember(long gid, long uid)
 		{
 			VkErrors.ThrowIfNumberIsNegative(() => gid);    // uid проверяет след. метод
@@ -310,8 +312,9 @@ namespace VkNet.Categories
 		/// <returns>В случае успешного выполнения возвращает true</returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.editManager"/>.
-		/// </remarks>		[Obsolete("Данный метод устарел. Используйте EditManager(GroupsEditManagerParams @params)")]
-		public bool EditManager(long groupId, long userId, AdminLevel? role, bool? isContact = null, string contactPosition = null, string contactPhone = null, string contactEmail = null)
+		/// </remarks>
+		[Obsolete("Данный метод устарел. Используйте EditManager(GroupsEditManagerParams @params)")]
+		public bool EditManager(long groupId, long userId, ManagerRole role, bool? isContact = null, string contactPosition = null, string contactPhone = null, string contactEmail = null)
 		{
 			VkErrors.ThrowIfNumberIsNegative(() => groupId);
 			VkErrors.ThrowIfNumberIsNegative(() => userId);
@@ -339,7 +342,7 @@ namespace VkNet.Categories
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.editManager"/>.
 		/// </remarks>
 		[Obsolete("Данный метод устарел. Используйте EditManager(GroupsEditManagerParams @params)")]
-		public bool EditManager(long groupId, long userId, AdminLevel? role)
+		public bool EditManager(long groupId, long userId, ManagerRole role)
 		{
 			// Проверка на неотрицательные значения в след. методе
 			return EditManager(groupId, userId, role, null);
@@ -360,7 +363,8 @@ namespace VkNet.Categories
 		/// </returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.getMembers" />.
-		/// </remarks>		[Obsolete("Данный метод устарел. Используйте GetMembers(GroupsGetMembersParams @params)")]
+		/// </remarks>
+		[Obsolete("Данный метод устарел. Используйте GetMembers(GroupsGetMembersParams @params)")]
 		public ReadOnlyCollection<User> GetMembers(out int totalCount, GroupsGetMembersParams @params)
 		{
 			var response = GetMembers(@params);
@@ -380,7 +384,8 @@ namespace VkNet.Categories
 		/// </returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.search" />.
-		/// </remarks>		[Obsolete("Данный метод устарел. Используйте Search(GroupsSearchParams @params)")]
+		/// </remarks>
+		[Obsolete("Данный метод устарел. Используйте Search(GroupsSearchParams @params)")]
 		public ReadOnlyCollection<Group> Search(out int totalCount, GroupsSearchParams @params)
 		{
 			var response = Search(@params);
@@ -435,7 +440,8 @@ namespace VkNet.Categories
 		/// <returns></returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте <see href="http://vk.com/dev/groups.getInvitedUsers" />.
-		/// </remarks>		[Obsolete("Данный метод устарел. Используйте GetInvitedUsers(long groupId, long? offset = null, long? count = null, UsersFields fields = null, NameCase nameCase = null)")]
+		/// </remarks>
+		[Obsolete("Данный метод устарел. Используйте GetInvitedUsers(long groupId, long? offset = null, long? count = null, UsersFields fields = null, NameCase nameCase = null)")]
 		public ReadOnlyCollection<User> GetInvitedUsers(long groupId, out int userCount, long? offset = null, long? count = null, UsersFields fields = null, NameCase nameCase = null)
 		{
 			var response = GetInvitedUsers(groupId, offset, count, fields, nameCase);

--- a/VkNet.UWP/Enums/SafetyEnums/ManagerRole.cs
+++ b/VkNet.UWP/Enums/SafetyEnums/ManagerRole.cs
@@ -1,0 +1,23 @@
+﻿namespace VkNet.Enums.SafetyEnums
+{
+    /// <summary>
+    /// Уровень полномочий пользователя в сообществе (Используется для задания полномочий пользователя в методе EditManager).
+    /// </summary>
+    public sealed class ManagerRole : SafetyEnum<ManagerRole>
+    {
+        /// <summary>
+        /// Пользователь является модератором собщества.
+        /// </summary>
+        public static readonly ManagerRole Moderator = RegisterPossibleValue("moderator");
+
+        /// <summary>
+        /// Пользователь является редактором сообщества.
+        /// </summary>
+        public static readonly ManagerRole Editor = RegisterPossibleValue("editor");
+
+        /// <summary>
+        /// Пользователь является администратором сообщества.
+        /// </summary>
+        public static readonly ManagerRole Administrator = RegisterPossibleValue("administrator");
+    }
+}

--- a/VkNet.UWP/Model/RequestParams/Groups/GroupsEditManagerParams.cs
+++ b/VkNet.UWP/Model/RequestParams/Groups/GroupsEditManagerParams.cs
@@ -1,4 +1,4 @@
-﻿using VkNet.Enums;
+﻿using VkNet.Enums.SafetyEnums;
 using VkNet.Utils;
 
 namespace VkNet.Model.RequestParams
@@ -42,7 +42,7 @@ namespace VkNet.Model.RequestParams
 		/// 
 		/// Если параметр не задан, с пользователя user_id снимаются полномочия руководителя. строка.
 		/// </summary>
-		public AdminLevel? Role { get; set; }
+		public ManagerRole Role { get; set; }
 
 		/// <summary>
 		/// Отображать ли пользователя в блоке контактов сообщества. флаг, может принимать значения 1 или 0.

--- a/VkNet.UWP/VkNet.UWP.csproj
+++ b/VkNet.UWP/VkNet.UWP.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Enums\SafetyEnums\LikeObjectType.cs" />
     <Compile Include="Enums\SafetyEnums\LikesFilter.cs" />
     <Compile Include="Enums\SafetyEnums\LinkAccessType.cs" />
+    <Compile Include="Enums\SafetyEnums\ManagerRole.cs" />
     <Compile Include="Enums\SafetyEnums\MediaType.cs" />
     <Compile Include="Enums\SafetyEnums\NameCase.cs" />
     <Compile Include="Enums\SafetyEnums\NewsObjectTypes.cs" />

--- a/VkNet/Enums/SafetyEnums/ManagerRole.cs
+++ b/VkNet/Enums/SafetyEnums/ManagerRole.cs
@@ -1,0 +1,23 @@
+﻿namespace VkNet.Enums.SafetyEnums
+{
+    /// <summary>
+    /// Уровень полномочий пользователя в сообществе (Используется для задания полномочий пользователя в методе EditManager).
+    /// </summary>
+    public sealed class ManagerRole : SafetyEnum<ManagerRole>
+    {
+        /// <summary>
+        /// Пользователь является модератором собщества.
+        /// </summary>
+        public static readonly ManagerRole Moderator = RegisterPossibleValue("moderator");
+
+        /// <summary>
+        /// Пользователь является редактором сообщества.
+        /// </summary>
+        public static readonly ManagerRole Editor = RegisterPossibleValue("editor");
+
+        /// <summary>
+        /// Пользователь является администратором сообщества.
+        /// </summary>
+        public static readonly ManagerRole Administrator = RegisterPossibleValue("administrator");
+    }
+}

--- a/VkNet/VkNet.csproj
+++ b/VkNet/VkNet.csproj
@@ -1224,6 +1224,7 @@
     <Compile Include="..\VkNet.UWP\VkApi.cs">
       <Link>VkApi.cs</Link>
     </Compile>
+    <Compile Include="Enums\SafetyEnums\ManagerRole.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
Восстановлена работа метода. Enum AdminLevel заменен на SafetyEnum

При вызове метода EditManager для определения роли пользователя использовался Enum AdminLevel который применяется для получения информации о группе. Однако в соответствии со спецификацией vk (https://vk.com/dev/groups.editManager) при вызове метода editManager в параметре role ожидается строковое значение "moderator", "editor","administrator".

Предлагаю для метода EditManager использовать отдельный SafetyEnum.