### PR TITLE
Fix: coordintaes в сообщениях всегда null

### DIFF
--- a/VkNet.UWP/Utils/VkResponse.cs
+++ b/VkNet.UWP/Utils/VkResponse.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.ObjectModel;
 using Newtonsoft.Json.Linq;
 using VkNet.Enums;
+using VkNet.Model;
 
 namespace VkNet.Utils
 {
@@ -463,7 +464,34 @@ namespace VkNet.Utils
 			return response == null ? null : Utilities.NullableEnumFrom<MessageReadState>(response);
 		}
 
-		#endregion
+        #endregion
 
-	}
+        #region Model exceptions
+        
+        /// <summary>
+        /// Преобразовать из VkResponse
+        /// </summary>
+        /// <param name="response">Ответ.</param>
+        /// <returns>
+        /// Результат преобразования.
+        /// </returns>
+        public static implicit operator Coordinates( VkResponse response )
+        {
+            return response?._token == null ? null : Coordinates.FromJson( response );
+        }
+
+        /// <summary>
+        /// Преобразовать из VkResponse
+        /// </summary>
+        /// <param name="response">Ответ.</param>
+        /// <returns>
+        /// Результат преобразования.
+        /// </returns>
+        public static implicit operator Collection<Coordinates>( VkResponse response )
+        {
+            return response.ToCollectionOf<Coordinates>( a => a );
+        }
+
+        #endregion
+    }
 }

--- a/VkNet.UWP/Utils/VkResponseToModelCastsGenerator.cs
+++ b/VkNet.UWP/Utils/VkResponseToModelCastsGenerator.cs
@@ -638,30 +638,6 @@ namespace VkNet.Utils
         /// <returns>
         /// Результат преобразования.
         /// </returns>
-		public static implicit operator Coordinates(VkResponse response)
-		{
-            return response?._token == null || !response._token.HasValues ? null :  Coordinates.FromJson(response);
-        }
-
-		/// <summary>
-        /// Преобразовать из VkResponse
-        /// </summary>
-        /// <param name="response">Ответ.</param>
-        /// <returns>
-        /// Результат преобразования.
-        /// </returns>
-		public static implicit operator Collection<Coordinates>(VkResponse response)
-        {
-            return response.ToCollectionOf<Coordinates>(a => a);
-        }
-
-		/// <summary>
-        /// Преобразовать из VkResponse
-        /// </summary>
-        /// <param name="response">Ответ.</param>
-        /// <returns>
-        /// Результат преобразования.
-        /// </returns>
 		public static implicit operator Counters(VkResponse response)
 		{
             return response?._token == null || !response._token.HasValues ? null :  Counters.FromJson(response);

--- a/VkNet.UWP/Utils/VkResponseToModelCastsGenerator.tt
+++ b/VkNet.UWP/Utils/VkResponseToModelCastsGenerator.tt
@@ -36,6 +36,8 @@ namespace VkNet.Utils
 
 	foreach (var type in types.OrderBy(s => s))
 		{
+		if (type == "Coordinates")
+			continue;
 #>
 		/// <summary>
         /// Преобразовать из VkResponse


### PR DESCRIPTION
## Список изменений
- Исключение в шаблоне для модели Coordinates #437 
