### PR TITLE
[Bug] Не везде заменены классы VkApiException на VkApiMethodException

### DIFF
--- a/VkNet.Shared.Tests/Categories/VideoCategoryTest.cs
+++ b/VkNet.Shared.Tests/Categories/VideoCategoryTest.cs
@@ -1,31 +1,33 @@
 ﻿using System;
 using System.Linq;
+using VkNet.Exception;
+using VkNet.Utils;
 
 namespace VkNet.Tests.Categories
 {
-	using NUnit.Framework;
+    using NUnit.Framework;
     using VkNet.Categories;
-	using Enums;
-	using Enums.Filters;
+    using Enums;
+    using Enums.Filters;
     using Enums.SafetyEnums;
 
 
-	[TestFixture]
+    [TestFixture]
     public class VideoCategoryTest : BaseTest
-	{
-         private VideoCategory GetMockedVideoCategory(string url, string json)
-         {
+    {
+        private VideoCategory GetMockedVideoCategory(string url, string json)
+        {
             Json = json;
             Url = url;
             return new VideoCategory(Api);
-         }
+        }
 
-         [Test]
-         public void Get_NotExtended()
-         {
-			const string url = "https://api.vk.com/method/video.get";
-			const string json =
-             @"{
+        [Test]
+        public void Get_NotExtended()
+        {
+            const string url = "https://api.vk.com/method/video.get";
+            const string json =
+                @"{
                     'response': {
                       'count': 8,
                       'items': [
@@ -72,60 +74,61 @@ namespace VkNet.Tests.Categories
                     }
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.Get(1, width:VideoWidth.Large320, count: 3, offset: 2);
-			Assert.That(result, Is.Not.Null);
-			Assert.That(result.Count, Is.EqualTo(3));
+            var result = cat.Get(1, width: VideoWidth.Large320, count: 3, offset: 2);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Count, Is.EqualTo(3));
 
-	        var video = result.FirstOrDefault();
-			Assert.That(video, Is.Not.Null);
-			Assert.That(video.Id, Is.EqualTo(166481021));
-			Assert.That(video.OwnerId, Is.EqualTo(1));
-			Assert.That(video.Title, Is.EqualTo("Лидия Аркадьевна"));
-			Assert.That(video.Duration, Is.EqualTo(131));
-			Assert.That(video.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867255)));
-			Assert.That(video.ViewsCount, Is.EqualTo(81676));
-			Assert.That(video.CommentsCount, Is.EqualTo(2098));
-			Assert.That(video.Photo130, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/s_af2727af.jpg")));
-			Assert.That(video.Photo320, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/l_aba9c1ab.jpg")));
-			Assert.That(video.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/VQaHFisdf-s")));
+            var video = result.FirstOrDefault();
+            Assert.That(video, Is.Not.Null);
+            Assert.That(video.Id, Is.EqualTo(166481021));
+            Assert.That(video.OwnerId, Is.EqualTo(1));
+            Assert.That(video.Title, Is.EqualTo("Лидия Аркадьевна"));
+            Assert.That(video.Duration, Is.EqualTo(131));
+            Assert.That(video.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867255)));
+            Assert.That(video.ViewsCount, Is.EqualTo(81676));
+            Assert.That(video.CommentsCount, Is.EqualTo(2098));
+            Assert.That(video.Photo130, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/s_af2727af.jpg")));
+            Assert.That(video.Photo320, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/l_aba9c1ab.jpg")));
+            Assert.That(video.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/VQaHFisdf-s")));
 
-			var video1 = result.Skip(1).FirstOrDefault();
-			Assert.That(video1, Is.Not.Null);
-			Assert.That(video1.Id, Is.EqualTo(166468673));
-			Assert.That(video1.OwnerId, Is.EqualTo(1));
-			Assert.That(video1.Title, Is.EqualTo("Лидия Аркадьевна"));
-			Assert.That(video1.Duration, Is.EqualTo(62));
-			Assert.That(video1.Description, Is.EqualTo(string.Empty));
-			Assert.That(video1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384721483)));
-			Assert.That(video1.ViewsCount, Is.EqualTo(42107));
-			Assert.That(video1.CommentsCount, Is.EqualTo(1243));
-			Assert.That(video1.Photo130, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/s_4e281f24.jpg")));
-			Assert.That(video1.Photo320, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/l_aa616ea2.jpg")));
-			Assert.That(video1.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/YfLytrkbAfM")));
+            var video1 = result.Skip(1).FirstOrDefault();
+            Assert.That(video1, Is.Not.Null);
+            Assert.That(video1.Id, Is.EqualTo(166468673));
+            Assert.That(video1.OwnerId, Is.EqualTo(1));
+            Assert.That(video1.Title, Is.EqualTo("Лидия Аркадьевна"));
+            Assert.That(video1.Duration, Is.EqualTo(62));
+            Assert.That(video1.Description, Is.EqualTo(string.Empty));
+            Assert.That(video1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384721483)));
+            Assert.That(video1.ViewsCount, Is.EqualTo(42107));
+            Assert.That(video1.CommentsCount, Is.EqualTo(1243));
+            Assert.That(video1.Photo130, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/s_4e281f24.jpg")));
+            Assert.That(video1.Photo320, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/l_aa616ea2.jpg")));
+            Assert.That(video1.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/YfLytrkbAfM")));
 
-			var video2 = result.Skip(2).FirstOrDefault();
-			Assert.That(video2, Is.Not.Null);
-			Assert.That(video2.Id, Is.EqualTo(164841344));
-			Assert.That(video2.OwnerId, Is.EqualTo(1));
-			Assert.That(video2.Title, Is.EqualTo("This is SPARTA"));
-			Assert.That(video2.Duration, Is.EqualTo(16));
-			Assert.That(video2.Description, Is.EqualTo(string.Empty));
-			Assert.That(video2.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1366495075)));
-			Assert.That(video2.ViewsCount, Is.EqualTo(218658));
-			Assert.That(video2.CommentsCount, Is.EqualTo(2578));
-			Assert.That(video2.Photo130, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/s_df53315c.jpg")));
-			Assert.That(video2.Photo320, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/l_00c6be47.jpg")));
-			Assert.That(video2.Player, Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=1&id=164841344&hash=c8de45fc73389353")));
-		}
+            var video2 = result.Skip(2).FirstOrDefault();
+            Assert.That(video2, Is.Not.Null);
+            Assert.That(video2.Id, Is.EqualTo(164841344));
+            Assert.That(video2.OwnerId, Is.EqualTo(1));
+            Assert.That(video2.Title, Is.EqualTo("This is SPARTA"));
+            Assert.That(video2.Duration, Is.EqualTo(16));
+            Assert.That(video2.Description, Is.EqualTo(string.Empty));
+            Assert.That(video2.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1366495075)));
+            Assert.That(video2.ViewsCount, Is.EqualTo(218658));
+            Assert.That(video2.CommentsCount, Is.EqualTo(2578));
+            Assert.That(video2.Photo130, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/s_df53315c.jpg")));
+            Assert.That(video2.Photo320, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/l_00c6be47.jpg")));
+            Assert.That(video2.Player,
+                Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=1&id=164841344&hash=c8de45fc73389353")));
+        }
 
-         [Test]
-         public void Get_Extended()
-         {
-			const string url = "https://api.vk.com/method/video.get";
-			const string json =
-             @"{
+        [Test]
+        public void Get_Extended()
+        {
+            const string url = "https://api.vk.com/method/video.get";
+            const string json =
+                @"{
                     'response': {
                       'count': 8,
                       'items': [
@@ -193,143 +196,144 @@ namespace VkNet.Tests.Categories
                     }
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.Get(1, width: VideoWidth.Large320, count: 3, offset: 2, extended:true);
+            var result = cat.Get(1, width: VideoWidth.Large320, count: 3, offset: 2, extended: true);
 
-			Assert.That(result, Is.Not.Null);
-			Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Count, Is.EqualTo(3));
 
-			var video = result.FirstOrDefault();
-			Assert.That(video, Is.Not.Null);
-			Assert.That(video.Id, Is.EqualTo(166481021));
-			Assert.That(video.OwnerId, Is.EqualTo(1));
-			Assert.That(video.Title, Is.EqualTo("Лидия Аркадьевна"));
-			Assert.That(video.Duration, Is.EqualTo(131));
-			Assert.That(video.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867255)));
-			Assert.That(video.ViewsCount, Is.EqualTo(81677));
-			Assert.That(video.CommentsCount, Is.EqualTo(2098));
-			Assert.That(video.Photo130, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/s_af2727af.jpg")));
-			Assert.That(video.Photo320, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/l_aba9c1ab.jpg")));
-			Assert.That(video.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/VQaHFisdf-s")));
-			Assert.That(video.CanComment, Is.EqualTo(true));
-			Assert.That(video.CanRepost, Is.EqualTo(true));
-			Assert.That(video.Repeat, Is.EqualTo(false));
-			Assert.That(video.Likes, Is.Not.Null);
-			Assert.That(video.Likes.UserLikes, Is.EqualTo(false));
-			Assert.That(video.Likes.Count, Is.EqualTo(1789));
+            var video = result.FirstOrDefault();
+            Assert.That(video, Is.Not.Null);
+            Assert.That(video.Id, Is.EqualTo(166481021));
+            Assert.That(video.OwnerId, Is.EqualTo(1));
+            Assert.That(video.Title, Is.EqualTo("Лидия Аркадьевна"));
+            Assert.That(video.Duration, Is.EqualTo(131));
+            Assert.That(video.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867255)));
+            Assert.That(video.ViewsCount, Is.EqualTo(81677));
+            Assert.That(video.CommentsCount, Is.EqualTo(2098));
+            Assert.That(video.Photo130, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/s_af2727af.jpg")));
+            Assert.That(video.Photo320, Is.EqualTo(new Uri("http://cs419529.vk.me/u9258277/video/l_aba9c1ab.jpg")));
+            Assert.That(video.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/VQaHFisdf-s")));
+            Assert.That(video.CanComment, Is.EqualTo(true));
+            Assert.That(video.CanRepost, Is.EqualTo(true));
+            Assert.That(video.Repeat, Is.EqualTo(false));
+            Assert.That(video.Likes, Is.Not.Null);
+            Assert.That(video.Likes.UserLikes, Is.EqualTo(false));
+            Assert.That(video.Likes.Count, Is.EqualTo(1789));
 
-			var video1 = result.Skip(1).FirstOrDefault();
-			Assert.That(video1, Is.Not.Null);
-			Assert.That(video1.Id, Is.EqualTo(166468673));
-			Assert.That(video1.OwnerId, Is.EqualTo(1));
-			Assert.That(video1.Title, Is.EqualTo("Лидия Аркадьевна"));
-			Assert.That(video1.Duration, Is.EqualTo(62));
-			Assert.That(video1.Description, Is.EqualTo(string.Empty));
-			Assert.That(video1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384721483)));
-			Assert.That(video1.ViewsCount, Is.EqualTo(42107));
-			Assert.That(video1.CommentsCount, Is.EqualTo(1243));
-			Assert.That(video1.Photo130, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/s_4e281f24.jpg")));
-			Assert.That(video1.Photo320, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/l_aa616ea2.jpg")));
-			Assert.That(video1.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/YfLytrkbAfM")));
+            var video1 = result.Skip(1).FirstOrDefault();
+            Assert.That(video1, Is.Not.Null);
+            Assert.That(video1.Id, Is.EqualTo(166468673));
+            Assert.That(video1.OwnerId, Is.EqualTo(1));
+            Assert.That(video1.Title, Is.EqualTo("Лидия Аркадьевна"));
+            Assert.That(video1.Duration, Is.EqualTo(62));
+            Assert.That(video1.Description, Is.EqualTo(string.Empty));
+            Assert.That(video1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384721483)));
+            Assert.That(video1.ViewsCount, Is.EqualTo(42107));
+            Assert.That(video1.CommentsCount, Is.EqualTo(1243));
+            Assert.That(video1.Photo130, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/s_4e281f24.jpg")));
+            Assert.That(video1.Photo320, Is.EqualTo(new Uri("http://cs409217.vk.me/u9258277/video/l_aa616ea2.jpg")));
+            Assert.That(video1.Player, Is.EqualTo(new Uri("http://www.youtube.com/embed/YfLytrkbAfM")));
 
-			Assert.That(video1.CanComment, Is.EqualTo(true));
-			Assert.That(video1.CanRepost, Is.EqualTo(true));
-			Assert.That(video1.Repeat, Is.EqualTo(false));
-			Assert.That(video1.Likes, Is.Not.Null);
-			Assert.That(video1.Likes.UserLikes, Is.EqualTo(false));
-			Assert.That(video1.Likes.Count, Is.EqualTo(640));
+            Assert.That(video1.CanComment, Is.EqualTo(true));
+            Assert.That(video1.CanRepost, Is.EqualTo(true));
+            Assert.That(video1.Repeat, Is.EqualTo(false));
+            Assert.That(video1.Likes, Is.Not.Null);
+            Assert.That(video1.Likes.UserLikes, Is.EqualTo(false));
+            Assert.That(video1.Likes.Count, Is.EqualTo(640));
 
-			var video2 = result.Skip(2).FirstOrDefault();
-			Assert.That(video2, Is.Not.Null);
-			Assert.That(video2.Id, Is.EqualTo(164841344));
-			Assert.That(video2.OwnerId, Is.EqualTo(1));
-			Assert.That(video2.Title, Is.EqualTo("This is SPARTA"));
-			Assert.That(video2.Duration, Is.EqualTo(16));
-			Assert.That(video2.Description, Is.EqualTo(string.Empty));
-			Assert.That(video2.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1366495075)));
-			Assert.That(video2.ViewsCount, Is.EqualTo(218659));
-			Assert.That(video2.CommentsCount, Is.EqualTo(2578));
-			Assert.That(video2.Photo130, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/s_df53315c.jpg")));
-			Assert.That(video2.Photo320, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/l_00c6be47.jpg")));
-			Assert.That(video2.Player, Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=1&id=164841344&hash=c8de45fc73389353")));
+            var video2 = result.Skip(2).FirstOrDefault();
+            Assert.That(video2, Is.Not.Null);
+            Assert.That(video2.Id, Is.EqualTo(164841344));
+            Assert.That(video2.OwnerId, Is.EqualTo(1));
+            Assert.That(video2.Title, Is.EqualTo("This is SPARTA"));
+            Assert.That(video2.Duration, Is.EqualTo(16));
+            Assert.That(video2.Description, Is.EqualTo(string.Empty));
+            Assert.That(video2.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1366495075)));
+            Assert.That(video2.ViewsCount, Is.EqualTo(218659));
+            Assert.That(video2.CommentsCount, Is.EqualTo(2578));
+            Assert.That(video2.Photo130, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/s_df53315c.jpg")));
+            Assert.That(video2.Photo320, Is.EqualTo(new Uri("http://cs12761.vk.me/u5705167/video/l_00c6be47.jpg")));
+            Assert.That(video2.Player,
+                Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=1&id=164841344&hash=c8de45fc73389353")));
 
-			Assert.That(video2.CanComment, Is.EqualTo(true));
-			Assert.That(video2.CanRepost, Is.EqualTo(true));
-			Assert.That(video2.Repeat, Is.EqualTo(true));
-			Assert.That(video2.Likes, Is.Not.Null);
-			Assert.That(video2.Likes.UserLikes, Is.EqualTo(true));
-			Assert.That(video2.Likes.Count, Is.EqualTo(4137));
-		}
+            Assert.That(video2.CanComment, Is.EqualTo(true));
+            Assert.That(video2.CanRepost, Is.EqualTo(true));
+            Assert.That(video2.Repeat, Is.EqualTo(true));
+            Assert.That(video2.Likes, Is.Not.Null);
+            Assert.That(video2.Likes.UserLikes, Is.EqualTo(true));
+            Assert.That(video2.Likes.Count, Is.EqualTo(4137));
+        }
 
-         [Test]
-         public void Add_NormalCase()
-         {
-             const string url = "https://api.vk.com/method/video.add";
-             const string json =
+        [Test]
+        public void Add_NormalCase()
+        {
+            const string url = "https://api.vk.com/method/video.add";
+            const string json =
                 @"{
                     'response': 167593944
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var id = cat.Add(164841344, 1);
-			Assert.That(id, Is.EqualTo(167593944));
-		}
+            var id = cat.Add(164841344, 1);
+            Assert.That(id, Is.EqualTo(167593944));
+        }
 
-         [Test]
-         public void Delete_NormalCase()
-         {
-             const string url = "https://api.vk.com/method/video.delete";
-             const string json =
+        [Test]
+        public void Delete_NormalCase()
+        {
+            const string url = "https://api.vk.com/method/video.delete";
+            const string json =
                 @"{
                     'response': 1
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.Delete(167593944);
-			Assert.That(result, Is.True);
-         }
+            var result = cat.Delete(167593944);
+            Assert.That(result, Is.True);
+        }
 
-         [Test]
-         public void Restore_NormalCase()
-         {
-             const string url = "https://api.vk.com/method/video.restore";
-             const string json =
+        [Test]
+        public void Restore_NormalCase()
+        {
+            const string url = "https://api.vk.com/method/video.restore";
+            const string json =
                 @"{
                     'response': 1
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.Restore(167593944);
-			Assert.That(result, Is.True);
-		}
+            var result = cat.Restore(167593944);
+            Assert.That(result, Is.True);
+        }
 
-         [Test]
-         public void AddAlbum_ToCurrentUser()
-         {
-             const string url = "https://api.vk.com/method/video.addAlbum";
-             const string json =
-				@"{
+        [Test]
+        public void AddAlbum_ToCurrentUser()
+        {
+            const string url = "https://api.vk.com/method/video.addAlbum";
+            const string json =
+                @"{
                     'response': {
                       'album_id': 49273471
                     }
                   }";
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var id = cat.AddAlbum("Новый альбом видеозаписей");
-			Assert.That(id, Is.EqualTo(49273471));
-		}
+            var id = cat.AddAlbum("Новый альбом видеозаписей");
+            Assert.That(id, Is.EqualTo(49273471));
+        }
 
-		// todo add not extended version
-		[Test]
-         public void GetAlbums_NormalCase_Extended_TwoItems()
-         {
-             const string url = "https://api.vk.com/method/video.getAlbums";
-             const string json =
-             @"{
+        // todo add not extended version
+        [Test]
+        public void GetAlbums_NormalCase_Extended_TwoItems()
+        {
+            const string url = "https://api.vk.com/method/video.getAlbums";
+            const string json =
+                @"{
                     'response': {
                       'count': 2,
                       'items': [
@@ -349,79 +353,81 @@ namespace VkNet.Tests.Categories
                     }
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.GetAlbums(234695119, extended:true);
-			Assert.That(result, Is.Not.Null);
-			Assert.That(result.Count, Is.EqualTo(2));
+            var result = cat.GetAlbums(234695119, extended: true);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Count, Is.EqualTo(2));
 
-			var videoAlbum = result.FirstOrDefault();
-			Assert.That(videoAlbum, Is.Not.Null);
-			Assert.That(videoAlbum.Id, Is.EqualTo(52154345));
-			Assert.That(videoAlbum.OwnerId, Is.EqualTo(234695119));
-			Assert.That(videoAlbum.Title, Is.EqualTo("Второй новый альбом видеозаписей"));
-			Assert.That(videoAlbum.Count, Is.EqualTo(0));
+            var videoAlbum = result.FirstOrDefault();
+            Assert.That(videoAlbum, Is.Not.Null);
+            Assert.That(videoAlbum.Id, Is.EqualTo(52154345));
+            Assert.That(videoAlbum.OwnerId, Is.EqualTo(234695119));
+            Assert.That(videoAlbum.Title, Is.EqualTo("Второй новый альбом видеозаписей"));
+            Assert.That(videoAlbum.Count, Is.EqualTo(0));
 
-			var videoAlbum1 = result.Skip(1).FirstOrDefault();
-			Assert.That(videoAlbum1, Is.Not.Null);
-			Assert.That(videoAlbum1.Id, Is.EqualTo(52152803));
-			Assert.That(videoAlbum1.OwnerId, Is.EqualTo(234695119));
-			Assert.That(videoAlbum1.Title, Is.EqualTo("Новый альбом видеозаписей"));
-			Assert.That(videoAlbum1.Count, Is.EqualTo(0));
-		}
+            var videoAlbum1 = result.Skip(1).FirstOrDefault();
+            Assert.That(videoAlbum1, Is.Not.Null);
+            Assert.That(videoAlbum1.Id, Is.EqualTo(52152803));
+            Assert.That(videoAlbum1.OwnerId, Is.EqualTo(234695119));
+            Assert.That(videoAlbum1.Title, Is.EqualTo("Новый альбом видеозаписей"));
+            Assert.That(videoAlbum1.Count, Is.EqualTo(0));
+        }
 
-         [Test]
-         public void DeleteAlbum_NormalCase()
-         {
-             const string url = "https://api.vk.com/method/video.deleteAlbum";
-             const string json =
+        [Test]
+        public void DeleteAlbum_NormalCase()
+        {
+            const string url = "https://api.vk.com/method/video.deleteAlbum";
+            const string json =
                 @"{
                     'response': 1
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.DeleteAlbum(52153813);
-			Assert.That(result, Is.True);
-         }
+            var result = cat.DeleteAlbum(52153813);
+            Assert.That(result, Is.True);
+        }
 
-         [Test]
-         public void EditAlbum_NormalCase()
-         {
-             const string url = "https://api.vk.com/method/video.editAlbum";
-             const string json =
+        [Test]
+        public void EditAlbum_NormalCase()
+        {
+            const string url = "https://api.vk.com/method/video.editAlbum";
+            const string json =
                 @"{
                     'response': 1
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.EditAlbum(521543, "Новое название!!!");
-			Assert.That(result, Is.True);
-		}
+            var result = cat.EditAlbum(521543, "Новое название!!!");
+            Assert.That(result, Is.True);
+        }
 
-         [Test, Ignore("Данный метод устарел и может быть отключён через некоторое время, пожалуйста, избегайте его использования.")]
-         public void MoveToAlbum_NormalCase()
-         {
-             const string url = "https://api.vk.com/method/video.moveToAlbum";
+        [Test,
+         Ignore(
+             "Данный метод устарел и может быть отключён через некоторое время, пожалуйста, избегайте его использования.")]
+        public void MoveToAlbum_NormalCase()
+        {
+            const string url = "https://api.vk.com/method/video.moveToAlbum";
 
-             const string json =
+            const string json =
                 @"{
                     'response': 1
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.MoveToAlbum(new long[] {167593938}, 52154378);
-			Assert.That(result, Is.True);
-		}
+            var result = cat.MoveToAlbum(new long[] {167593938}, 52154378);
+            Assert.That(result, Is.True);
+        }
 
-         [Test]
-         public void GetComments_WithLikes()
-         {
-			const string url = "https://api.vk.com/method/video.getComments";
-			const string json =
-             @"{
+        [Test]
+        public void GetComments_WithLikes()
+        {
+            const string url = "https://api.vk.com/method/video.getComments";
+            const string json =
+                @"{
                     'response': {
                       'count': 2146,
                       'items': [
@@ -451,41 +457,43 @@ namespace VkNet.Tests.Categories
                     }
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var comments = cat.GetComments(166481021, 1, true, 2, 3, CommentsSort.Asc);
-			Assert.That(comments, Is.Not.Null);
-			Assert.That(comments.Count, Is.EqualTo(2));
+            var comments = cat.GetComments(166481021, 1, true, 2, 3, CommentsSort.Asc);
+            Assert.That(comments, Is.Not.Null);
+            Assert.That(comments.Count, Is.EqualTo(2));
 
-			var comment = comments.FirstOrDefault();
-			Assert.That(comment, Is.Not.Null);
+            var comment = comments.FirstOrDefault();
+            Assert.That(comment, Is.Not.Null);
 
-			Assert.That(comment.Id, Is.EqualTo(14715));
-			Assert.That(comment.FromId, Is.EqualTo(24758120));
-			Assert.That(comment.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867361)));
-			Assert.That(comment.Text, Is.EqualTo("паша здаров!"));
-			Assert.That(comment.Likes.Count, Is.EqualTo(5));
-			Assert.That(comment.Likes.UserLikes, Is.EqualTo(false));
-			Assert.That(comment.Likes.CanLike, Is.EqualTo(true));
+            Assert.That(comment.Id, Is.EqualTo(14715));
+            Assert.That(comment.FromId, Is.EqualTo(24758120));
+            Assert.That(comment.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867361)));
+            Assert.That(comment.Text, Is.EqualTo("паша здаров!"));
+            Assert.That(comment.Likes.Count, Is.EqualTo(5));
+            Assert.That(comment.Likes.UserLikes, Is.EqualTo(false));
+            Assert.That(comment.Likes.CanLike, Is.EqualTo(true));
 
-			var comment1 = comments.Skip(1).FirstOrDefault();
-			Assert.That(comment1, Is.Not.Null);
+            var comment1 = comments.Skip(1).FirstOrDefault();
+            Assert.That(comment1, Is.Not.Null);
 
-			Assert.That(comment1.Id, Is.EqualTo(14716));
-			Assert.That(comment1.FromId, Is.EqualTo(94278436));
-			Assert.That(comment1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867372)));
-			Assert.That(comment1.Text, Is.EqualTo("Я опять на странице Дурова, опять передаю привет Маме, Бабушке и своим друзьям! Дела у меня очень отлично!"));
-			Assert.That(comment1.Likes.Count, Is.EqualTo(77));
-			Assert.That(comment1.Likes.UserLikes, Is.EqualTo(false));
-			Assert.That(comment1.Likes.CanLike, Is.EqualTo(true));
-		}
+            Assert.That(comment1.Id, Is.EqualTo(14716));
+            Assert.That(comment1.FromId, Is.EqualTo(94278436));
+            Assert.That(comment1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867372)));
+            Assert.That(comment1.Text,
+                Is.EqualTo(
+                    "Я опять на странице Дурова, опять передаю привет Маме, Бабушке и своим друзьям! Дела у меня очень отлично!"));
+            Assert.That(comment1.Likes.Count, Is.EqualTo(77));
+            Assert.That(comment1.Likes.UserLikes, Is.EqualTo(false));
+            Assert.That(comment1.Likes.CanLike, Is.EqualTo(true));
+        }
 
-		[Test]
-         public void GetComments_WithoutLikes()
-         {
-			const string url = "https://api.vk.com/method/video.getComments";
-			const string json =
-             @"{
+        [Test]
+        public void GetComments_WithoutLikes()
+        {
+            const string url = "https://api.vk.com/method/video.getComments";
+            const string json =
+                @"{
                     'response': {
                       'count': 2146,
                       'items': [
@@ -505,33 +513,35 @@ namespace VkNet.Tests.Categories
                     }
                   }";
 
-             var cat = GetMockedVideoCategory(url, json);
+            var cat = GetMockedVideoCategory(url, json);
 
-			var comments = cat.GetComments(166481021, 1, false, 2, 3, CommentsSort.Asc);
-			Assert.That(comments, Is.Not.Null);
-			Assert.That(comments.Count, Is.EqualTo(2));
+            var comments = cat.GetComments(166481021, 1, false, 2, 3, CommentsSort.Asc);
+            Assert.That(comments, Is.Not.Null);
+            Assert.That(comments.Count, Is.EqualTo(2));
 
-			var comment = comments.FirstOrDefault();
-			Assert.That(comment, Is.Not.Null);
+            var comment = comments.FirstOrDefault();
+            Assert.That(comment, Is.Not.Null);
 
-			Assert.That(comment.Id, Is.EqualTo(14715));
-			Assert.That(comment.FromId, Is.EqualTo(24758120));
-			Assert.That(comment.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867361)));
-			Assert.That(comment.Text, Is.EqualTo("паша здаров!"));
+            Assert.That(comment.Id, Is.EqualTo(14715));
+            Assert.That(comment.FromId, Is.EqualTo(24758120));
+            Assert.That(comment.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867361)));
+            Assert.That(comment.Text, Is.EqualTo("паша здаров!"));
 
-			var comment1 = comments.Skip(1).FirstOrDefault();
-			Assert.That(comment1, Is.Not.Null);
-			Assert.That(comment1.Id, Is.EqualTo(14716));
-			Assert.That(comment1.FromId, Is.EqualTo(94278436));
-			Assert.That(comment1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867372)));
-			Assert.That(comment1.Text, Is.EqualTo("Я опять на странице Дурова, опять передаю привет Маме, Бабушке и своим друзьям! Дела у меня очень отлично!"));
-		}
+            var comment1 = comments.Skip(1).FirstOrDefault();
+            Assert.That(comment1, Is.Not.Null);
+            Assert.That(comment1.Id, Is.EqualTo(14716));
+            Assert.That(comment1.FromId, Is.EqualTo(94278436));
+            Assert.That(comment1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384867372)));
+            Assert.That(comment1.Text,
+                Is.EqualTo(
+                    "Я опять на странице Дурова, опять передаю привет Маме, Бабушке и своим друзьям! Дела у меня очень отлично!"));
+        }
 
-		[Test]
+        [Test]
         public void Search_NormalCase_ListOfVideos()
         {
-			const string url = "https://api.vk.com/method/video.search";
-			const string json =
+            const string url = "https://api.vk.com/method/video.search";
+            const string json =
                 @"{
                     'response': {
                       'count': 1425,
@@ -583,70 +593,83 @@ namespace VkNet.Tests.Categories
             var cat = GetMockedVideoCategory(url, json);
 
             var result = cat.Search("саша грей", VideoSort.Relevance, false, true, VideoFilters.Long, false, 5, 1);
-			Assert.That(result, Is.Not.Null);
-			Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Count, Is.EqualTo(3));
 
-			var video = result.FirstOrDefault();
-			Assert.That(video, Is.Not.Null);
+            var video = result.FirstOrDefault();
+            Assert.That(video, Is.Not.Null);
 
-			Assert.That(video.Id, Is.EqualTo(166671614));
-			Assert.That(video.OwnerId, Is.EqualTo(-59205334));
-			Assert.That(video.Title, Is.EqualTo("Fucking Machines Sasha Grey | Саша Грей | Саша Грэй  | Порно | Секс | Эротика | Секс машина |  Садо-мазо  | БДСМ"));
-			Assert.That(video.Duration, Is.EqualTo(1934));
-			Assert.That(video.Description, Is.EqualTo("beauty 18+\n\n\'Качественное и эксклюзивное порно  у нас\'\n\n>>>>>>> http://vk.com/mastofmastur<<<<<<"));
-			Assert.That(video.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384706962)));
-			Assert.That(video.ViewsCount, Is.EqualTo(11579));
-			Assert.That(video.CommentsCount, Is.EqualTo(12));
-			Assert.That(video.Photo130, Is.EqualTo(new Uri("http://cs505118.vk.me/u7160710/video/s_08382000.jpg")));
-			Assert.That(video.Photo320, Is.EqualTo(new Uri("http://cs505118.vk.me/u7160710/video/l_a02ed037.jpg")));
-			Assert.That(video.AlbumId, Is.EqualTo(50100051));
-			Assert.That(video.Player, Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=-59205334&id=166671614&hash=d609a7775bbb2e7d")));
+            Assert.That(video.Id, Is.EqualTo(166671614));
+            Assert.That(video.OwnerId, Is.EqualTo(-59205334));
+            Assert.That(video.Title,
+                Is.EqualTo(
+                    "Fucking Machines Sasha Grey | Саша Грей | Саша Грэй  | Порно | Секс | Эротика | Секс машина |  Садо-мазо  | БДСМ"));
+            Assert.That(video.Duration, Is.EqualTo(1934));
+            Assert.That(video.Description,
+                Is.EqualTo(
+                    "beauty 18+\n\n\'Качественное и эксклюзивное порно  у нас\'\n\n>>>>>>> http://vk.com/mastofmastur<<<<<<"));
+            Assert.That(video.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1384706962)));
+            Assert.That(video.ViewsCount, Is.EqualTo(11579));
+            Assert.That(video.CommentsCount, Is.EqualTo(12));
+            Assert.That(video.Photo130, Is.EqualTo(new Uri("http://cs505118.vk.me/u7160710/video/s_08382000.jpg")));
+            Assert.That(video.Photo320, Is.EqualTo(new Uri("http://cs505118.vk.me/u7160710/video/l_a02ed037.jpg")));
+            Assert.That(video.AlbumId, Is.EqualTo(50100051));
+            Assert.That(video.Player,
+                Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=-59205334&id=166671614&hash=d609a7775bbb2e7d")));
 
-			var video1 = result.Skip(1).FirstOrDefault();
-			Assert.That(video1, Is.Not.Null);
+            var video1 = result.Skip(1).FirstOrDefault();
+            Assert.That(video1, Is.Not.Null);
 
-			Assert.That(video1.Id, Is.EqualTo(165458571));
-			Assert.That(video1.OwnerId, Is.EqualTo(-49956637));
-			Assert.That(video1.Title, Is.EqualTo("домашнее частное порно порно модель саша грей on-line любовь порно с сюжетом лесби порка стендап stand up клип группа"));
-			Assert.That(video1.Duration, Is.EqualTo(1139));
-			Assert.That(video1.Description, Is.EqualTo("секс знакомства подписывайся,знакомься,общайся,тут русские шлюхи,проститутки подпишись у нас http://vk.com/tyt_sex"));
-			Assert.That(video1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1371702618)));
-			Assert.That(video1.ViewsCount, Is.EqualTo(12817));
-			Assert.That(video1.CommentsCount, Is.EqualTo(5));
-			Assert.That(video1.Photo130, Is.EqualTo(new Uri("http://cs527502.vk.me/u65226705/video/s_1d867e81.jpg")));
-			Assert.That(video1.Photo320, Is.EqualTo(new Uri("http://cs527502.vk.me/u65226705/video/l_ba2e1aff.jpg")));
-			Assert.That(video1.Player, Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=-49956637&id=165458571&hash=dc6995a7cc9aed92")));
+            Assert.That(video1.Id, Is.EqualTo(165458571));
+            Assert.That(video1.OwnerId, Is.EqualTo(-49956637));
+            Assert.That(video1.Title,
+                Is.EqualTo(
+                    "домашнее частное порно порно модель саша грей on-line любовь порно с сюжетом лесби порка стендап stand up клип группа"));
+            Assert.That(video1.Duration, Is.EqualTo(1139));
+            Assert.That(video1.Description,
+                Is.EqualTo(
+                    "секс знакомства подписывайся,знакомься,общайся,тут русские шлюхи,проститутки подпишись у нас http://vk.com/tyt_sex"));
+            Assert.That(video1.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1371702618)));
+            Assert.That(video1.ViewsCount, Is.EqualTo(12817));
+            Assert.That(video1.CommentsCount, Is.EqualTo(5));
+            Assert.That(video1.Photo130, Is.EqualTo(new Uri("http://cs527502.vk.me/u65226705/video/s_1d867e81.jpg")));
+            Assert.That(video1.Photo320, Is.EqualTo(new Uri("http://cs527502.vk.me/u65226705/video/l_ba2e1aff.jpg")));
+            Assert.That(video1.Player,
+                Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=-49956637&id=165458571&hash=dc6995a7cc9aed92")));
 
-			var video2 = result.Skip(2).FirstOrDefault();
-			Assert.That(video2, Is.Not.Null);
+            var video2 = result.Skip(2).FirstOrDefault();
+            Assert.That(video2, Is.Not.Null);
 
-			Assert.That(video2.Id, Is.EqualTo(166728490));
-			Assert.That(video2.OwnerId, Is.EqualTo(-54257090));
-			Assert.That(video2.Title, Is.EqualTo("Саша Грей | Sasha Grey #13"));
-			Assert.That(video2.Duration, Is.EqualTo(1289));
-			Assert.That(video2.Description, Is.EqualTo("Взято со страницы Саша Грей | Sasha Grey | 18+: http://vk.com/sashagreyphotos\nЭротика: http://vk.com/gentleerotica"));
-			Assert.That(video2.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1386961568)));
-			Assert.That(video2.ViewsCount, Is.EqualTo(8730));
-			Assert.That(video2.CommentsCount, Is.EqualTo(12));
-			Assert.That(video2.Photo130, Is.EqualTo(new Uri("http://cs535107.vk.me/u146564541/video/s_2d874147.jpg")));
-			Assert.That(video2.Photo320, Is.EqualTo(new Uri("http://cs535107.vk.me/u146564541/video/l_cb794198.jpg")));
-			Assert.That(video2.Player, Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=-54257090&id=166728490&hash=15a0552ca76bedac")));
-		}
+            Assert.That(video2.Id, Is.EqualTo(166728490));
+            Assert.That(video2.OwnerId, Is.EqualTo(-54257090));
+            Assert.That(video2.Title, Is.EqualTo("Саша Грей | Sasha Grey #13"));
+            Assert.That(video2.Duration, Is.EqualTo(1289));
+            Assert.That(video2.Description,
+                Is.EqualTo(
+                    "Взято со страницы Саша Грей | Sasha Grey | 18+: http://vk.com/sashagreyphotos\nЭротика: http://vk.com/gentleerotica"));
+            Assert.That(video2.Date, Is.EqualTo(DateHelper.TimeStampToDateTime(1386961568)));
+            Assert.That(video2.ViewsCount, Is.EqualTo(8730));
+            Assert.That(video2.CommentsCount, Is.EqualTo(12));
+            Assert.That(video2.Photo130, Is.EqualTo(new Uri("http://cs535107.vk.me/u146564541/video/s_2d874147.jpg")));
+            Assert.That(video2.Photo320, Is.EqualTo(new Uri("http://cs535107.vk.me/u146564541/video/l_cb794198.jpg")));
+            Assert.That(video2.Player,
+                Is.EqualTo(new Uri("http://vk.com/video_ext.php?oid=-54257090&id=166728490&hash=15a0552ca76bedac")));
+        }
 
-		[Test]
+        [Test]
         public void CreateComment_NormalCase()
         {
-			const string url = "https://api.vk.com/method/video.createComment";
-			const string json =
+            const string url = "https://api.vk.com/method/video.createComment";
+            const string json =
                 @"{
                     'response': 35634
                   }";
 
             var cat = GetMockedVideoCategory(url, json);
 
-			var id = cat.CreateComment(166613182, "забавное видео", 1);
-			Assert.That(id, Is.EqualTo(35634));
-		}
+            var id = cat.CreateComment(166613182, "забавное видео", 1);
+            Assert.That(id, Is.EqualTo(35634));
+        }
 
         [Test]
         public void DeleteComment_NormalCase()
@@ -659,8 +682,8 @@ namespace VkNet.Tests.Categories
 
             var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.DeleteComment(35634, 1);
-			Assert.That(result, Is.True);
+            var result = cat.DeleteComment(35634, 1);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -674,24 +697,24 @@ namespace VkNet.Tests.Categories
 
             var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.RestoreComment(35634, 1);
-			Assert.That(result, Is.True);
-		}
+            var result = cat.RestoreComment(35634, 1);
+            Assert.That(result, Is.True);
+        }
 
         [Test]
         public void EditComment_NormalCase()
         {
-			const string url = "https://api.vk.com/method/video.editComment";
-			const string json =
+            const string url = "https://api.vk.com/method/video.editComment";
+            const string json =
                 @"{
                     'response': 1
                   }";
 
             var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.EditComment(35634, "суперское видео", 1);
-			Assert.That(result, Is.True);
-		}
+            var result = cat.EditComment(35634, "суперское видео", 1);
+            Assert.That(result, Is.True);
+        }
 
         [Test]
         public void Report_NormalCase()
@@ -704,9 +727,9 @@ namespace VkNet.Tests.Categories
 
             var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.Report(166613182, Enums.ReportReason.DrugPropaganda, 1, "коммент");
-			Assert.That(result, Is.True);
-		}
+            var result = cat.Report(166613182, Enums.ReportReason.DrugPropaganda, 1, "коммент");
+            Assert.That(result, Is.True);
+        }
 
         [Test]
         public void ReportComment_NormalCase()
@@ -720,29 +743,29 @@ namespace VkNet.Tests.Categories
             var cat = GetMockedVideoCategory(url, json);
 
             var result = cat.ReportComment(35637, 1, Enums.ReportReason.AdultMaterial);
-			Assert.That(result, Is.True);
-		}
+            Assert.That(result, Is.True);
+        }
 
         [Test]
         public void Edit_NormalCase()
         {
-			const string url = "https://api.vk.com/method/video.edit";
-			const string json =
+            const string url = "https://api.vk.com/method/video.edit";
+            const string json =
                 @"{
                     'response': 1
                   }";
 
             var cat = GetMockedVideoCategory(url, json);
 
-			var result = cat.Edit(167538, 23469, "Новое название", "Новое описание");
-			Assert.That(result, Is.True);
-		}
+            var result = cat.Edit(167538, 23469, "Новое название", "Новое описание");
+            Assert.That(result, Is.True);
+        }
 
         [Test]
         public void Save_NormalCase()
         {
-			const string url = "https://api.vk.com/method/video.save";
-			const string json =
+            const string url = "https://api.vk.com/method/video.save";
+            const string json =
                 @"{
                     'response': {
                       'upload_url': 'http://cs6058.vk.com/upload.php?act=parse_share&hash=d5371f57b935d1b3b0c6cde1100ecb&rhash=5c623ee8b80db0d3af5078a5dfb2&mid=234695118&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DlhQtzv5a408&api_callback=06ec8115dfc9a66eec&remotely=1&photo_server=607423&photo_server_hash=7874a144e80b8bb3c1a1eee5c9043',
@@ -756,15 +779,53 @@ namespace VkNet.Tests.Categories
 
             var cat = GetMockedVideoCategory(url, json);
 
-            var video = cat.Save("Название из ютуба", "Описание из ютуба", isPostToWall: true, link: "https://www.youtube.com/watch?v=lhQtzv5a408&list=PLBC36AAAE4E4E0CAA");
-			Assert.That(video, Is.Not.Null);
-			Assert.That(video.Id, Is.EqualTo(1673994));
-			Assert.That(video.OwnerId, Is.EqualTo(2346958));
-			Assert.That(video.Title, Is.EqualTo("Название из ютуба"));
-			Assert.That(video.Description, Is.EqualTo("Описание из ютуба"));
-			Assert.That(video.AccessKey, Is.EqualTo("f2ec9f3982f05bc"));
-			Assert.That(video.UploadUrl, Is.EqualTo(new Uri("http://cs6058.vk.com/upload.php?act=parse_share&hash=d5371f57b935d1b3b0c6cde1100ecb&rhash=5c623ee8b80db0d3af5078a5dfb2&mid=234695118&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DlhQtzv5a408&api_callback=06ec8115dfc9a66eec&remotely=1&photo_server=607423&photo_server_hash=7874a144e80b8bb3c1a1eee5c9043")));
-		}
+            var video = cat.Save("Название из ютуба", "Описание из ютуба", isPostToWall: true,
+                link: "https://www.youtube.com/watch?v=lhQtzv5a408&list=PLBC36AAAE4E4E0CAA");
+            Assert.That(video, Is.Not.Null);
+            Assert.That(video.Id, Is.EqualTo(1673994));
+            Assert.That(video.OwnerId, Is.EqualTo(2346958));
+            Assert.That(video.Title, Is.EqualTo("Название из ютуба"));
+            Assert.That(video.Description, Is.EqualTo("Описание из ютуба"));
+            Assert.That(video.AccessKey, Is.EqualTo("f2ec9f3982f05bc"));
+            Assert.That(video.UploadUrl,
+                Is.EqualTo(new Uri(
+                    "http://cs6058.vk.com/upload.php?act=parse_share&hash=d5371f57b935d1b3b0c6cde1100ecb&rhash=5c623ee8b80db0d3af5078a5dfb2&mid=234695118&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DlhQtzv5a408&api_callback=06ec8115dfc9a66eec&remotely=1&photo_server=607423&photo_server_hash=7874a144e80b8bb3c1a1eee5c9043")));
+        }
 
+        [Test]
+        public void Save_ReturnError()
+        {
+            const string json =
+                @"{
+   'error' : {
+      'error_code' : 204,
+      'error_msg' : 'Access denied: user was banned for this action, cant add video',
+      'request_params' : [
+         {
+            'key' : 'oauth',
+            'value' : '1'
+         },
+         {
+            'key' : 'method',
+            'value' : 'video.save'
+         },
+         
+         {
+            'key' : 'description',
+            'value' : '123'
+         },
+         {
+            'key' : 'group_id',
+            'value' : '33905270'
+         },
+         {
+            'key' : 'v',
+            'value' : '5.64'
+         }
+      ]
+   }
+}";
+            Assert.That(() => VkErrors.IfErrorThrowException(json), Throws.TypeOf<VideoAccessDeniedException>());
+        }
     }
 }

--- a/VkNet.Shared.Tests/Categories/WallCategoryTest.cs
+++ b/VkNet.Shared.Tests/Categories/WallCategoryTest.cs
@@ -11,6 +11,7 @@ using VkNet.Exception;
 using VkNet.Model;
 using VkNet.Model.Attachments;
 using VkNet.Model.RequestParams;
+using VkNet.Utils;
 
 namespace VkNet.Tests.Categories
 {
@@ -631,12 +632,53 @@ namespace VkNet.Tests.Categories
 
 		}
 
+	    [Test]
+	    public void Post_ReturnValidateNeeded()
+	    {
+	        const string json =
+	            @"
+                {
+                    'error' : {
+                    'error_code' : 17,
+                    'error_msg' : 'Validation required: please open redirect_uri in browser',
+                    'redirect_uri' : 'https://m.vk.com/activation?act=validate&api_hash=****&hash=***',
+                    'request_params' : [
+                        {
+                        'key' : 'oauth',
+                        'value' : '1'
+                        },
+                        {
+                        'key' : 'method',
+                        'value' : 'wall.post'
+                        },
+                        {
+                        'key' : 'owner_id',
+                        'value' : '-153877099'
+                        },
+                        {
+                        'key' : 'from_group',
+                        'value' : '1'
+                        },
+                        {
+                        'key' : 'message',
+                        'value' : 'Test'
+                        },
+                        {
+                        'key' : 'v',
+                        'value' : '5.64'
+                        }
+                    ]
+                    }
+                 }
+                 ";
+	        Assert.That(() => VkErrors.IfErrorThrowException(json), Throws.TypeOf<NeedValidationException>());
+	    }
 
-		#endregion
+        #endregion
 
-		#region Wall.Repost
+        #region Wall.Repost
 
-		[Test]
+        [Test]
 		public void Repost_AccessTokenInvalid_ThrowAccessTokenInvalidException()
 		{
 			Assert.That(() => _defaultWall.Repost("id"), Throws.InstanceOf<AccessTokenInvalidException>());

--- a/VkNet.Tests/VkNet.Tests.csproj
+++ b/VkNet.Tests/VkNet.Tests.csproj
@@ -41,11 +41,32 @@
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net40\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\VkNet.Shared.Tests\BaseTest.cs">
@@ -152,6 +173,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/VkNet.Tests/app.config
+++ b/VkNet.Tests/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/VkNet.Tests/packages.config
+++ b/VkNet.Tests/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
+  <package id="NUnit" version="3.8.1" targetFramework="net40" />
+</packages>

--- a/VkNet.UWP/Exception/NeedValidationException.cs
+++ b/VkNet.UWP/Exception/NeedValidationException.cs
@@ -18,7 +18,7 @@ namespace VkNet.Exception
 	/// Код ошибки - 17
     /// </summary>
     [DataContract]
-    public class NeedValidationException : VkApiException
+    public class NeedValidationException : VkApiMethodInvokeException
     {
         /// <summary>
         /// Адрес который необходимо открыть в браузере.

--- a/VkNet/VkNet.csproj
+++ b/VkNet/VkNet.csproj
@@ -49,9 +49,8 @@
       <HintPath>..\packages\AngleSharp.0.9.9\lib\net40\AngleSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.4.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.4.0\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JetBrains.Annotations, Version=11.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.11.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -66,7 +65,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/VkNet/packages.config
+++ b/VkNet/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net40" />
-  <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net40" />
+  <package id="JetBrains.Annotations" version="11.0.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
## Список изменений
- В части классов не заменён базовый класс с VkApiException на VkApiMethodException.
Из-за этого возникает ошибка, в частности при требовании подтверждении аккаунта.
(Возможно необходимо произвести аналогичную замену в классах :
AccessTokenInvalidException
PostLimitException
VkApiAuthorizationException
- Добавлены UnitTest'ы на проверку исключений при сохранении видео и создании поста на стене