### PR TITLE
Исправление ошиби метода Messages.Edit

### DIFF
--- a/VkNet/Categories/MessagesCategory.cs
+++ b/VkNet/Categories/MessagesCategory.cs
@@ -902,7 +902,7 @@ namespace VkNet.Categories
         /// <inheritdoc />
         public bool Edit(MessageEditParams @params)
         {
-            return _vk.Call("messages.markAsImportantDialog", @params);
+            return _vk.Call("messages.edit", @params);
         }
     }
 }


### PR DESCRIPTION
## Список изменений
- Изменение 1
Вызывался неверный метод messages.markAsImportant вместо messages.edit при вызове метода для редактирвоания сообщения
