### PR TITLE
Значения полей для POST запросов

### DIFF
--- a/VkNet/Utils/Async/WebCall.Async.cs
+++ b/VkNet/Utils/Async/WebCall.Async.cs
@@ -53,7 +53,7 @@ namespace VkNet.Utils
             {
                 SpecifyHeadersForFormRequest(form, call);
 
-                var request = await call._request.PostAsync(form.ActionUrl, new FormUrlEncodedContent(GetParameterList(form)));
+                var request = await call._request.PostAsync(form.ActionUrl, new FormUrlEncodedContent(form.GetFormFields()));
                 return await call.MakeRequestAsync(request, new Uri(form.ActionUrl), webProxy);
             }
         }

--- a/VkNet/Utils/WebCall.cs
+++ b/VkNet/Utils/WebCall.cs
@@ -95,7 +95,7 @@ namespace VkNet.Utils
             {
                 SpecifyHeadersForFormRequest(form, call);
 
-                var request = call._request.PostAsync(form.ActionUrl, new FormUrlEncodedContent(GetParameterList(form))).Result;
+                var request = call._request.PostAsync(form.ActionUrl, new FormUrlEncodedContent(form.GetFormFields())).Result;
                 return call.MakeRequest(request, new Uri(form.ActionUrl), webProxy);
             }
         }
@@ -148,26 +148,7 @@ namespace VkNet.Utils
                         : _result;
             }
         }
-
-        private static IDictionary<string, string> GetParameterList(WebForm form)
-        {
-            var paramList = new Dictionary<string, string>();
-            foreach (var param in form.GetRequestAsStringArray())
-            {
-                if (paramList.ContainsKey(param))
-                {
-                    continue;
-                }
-
-                var paramPair = param.Split('=');
-                var key = paramPair[0] + "";
-                var value = paramPair[1] + "";
-                paramList.Add(key, value);
-            }
-
-            return paramList;
-        }
-
+        
         private static void SpecifyHeadersForFormRequest(WebForm form, WebCall call)
         {
             var formRequest = form.GetRequest();

--- a/VkNet/Utils/WebForm.cs
+++ b/VkNet/Utils/WebForm.cs
@@ -168,6 +168,13 @@
     /// <returns>Массив байт</returns>
     public IEnumerable<string> GetRequestAsStringArray() => _inputs.Select(x => $"{x.Key}={x.Value}");
 
+
+    /// <summary>
+    /// Получить значения полей.
+    /// </summary>
+    /// <returns>Словарь значений по именам полей.</returns>
+    public IDictionary<string, string> GetFormFields() => new Dictionary<string, string>(_inputs, _inputs.Comparer);
+
     /// <summary>
     /// Разобрать поля ввода.
     /// </summary>


### PR DESCRIPTION
Исправлено получение значений полей формы для POST запросов.

## Список изменений
- В классе WebForm добавлен метод GetFormFields для получения значений полей формы. Возвращается копия словаря значений, чтобы разработчик случайно(или преднамеренно) не мог изменять внутренний словарь значений полей формы
- Удалён метод WebCall.GetParameterList по трём причинам:
1) По предыдущей логике работы, чтобы получить значения полей формы, словарь значений сначала "сериализуется" в текст, а затем в этой функции происходит парсинг этого текста обратно в словарь. Это порождается ненужные накладные расходы.
2) Неправильно реализована логика парсинга: Split('=') Некорректно обрабатывались кейсы, когда в значении параметра присутствовал символ '='(равно), в результате значения обрезались. Так например, если передан пароль 'pass=word', то в теле POST запроса присутствовало значение 'pass'.
3) Вызов метода заменён на вызов WebForm.GetFormFields()