### PR TITLE
исправил зависание таска в TryInvokeMethodAsync

### DIFF
--- a/VkNet/Utils/TypeHelper.cs
+++ b/VkNet/Utils/TypeHelper.cs
@@ -101,7 +101,11 @@ namespace VkNet.Utils
 						var result = func.Invoke();
 						tcs.SetResult(result);
 					}
-					catch (VkApiException ex)
+					catch (OperationCanceledException)
+					{
+						tcs.SetCanceled();
+					}
+					catch (System.Exception ex)
 					{
 						tcs.SetException(ex);
 					}
@@ -127,7 +131,11 @@ namespace VkNet.Utils
 					func.Invoke();
 					tcs.SetResult(null);
 				}
-				catch (VkApiException ex)
+				catch (OperationCanceledException)
+				{
+					tcs.SetCanceled();
+				}
+				catch (System.Exception ex)
 				{
 					tcs.SetException(ex);
 				}


### PR DESCRIPTION
## Список изменений
- Добавил обработку OperationCanceledException с последующим вызовом SetCanceled(); для TaskCompletionSource, что бы пользовательский код мог корректно обработать отмену какой-либо задачи(например timeout rest клиента)

- Изменил ловлю VkApiException на System.Exception, что бы исправить вечное ожидание в случае, если прилетит екзепшн, отличный от VkApiException (вечное ожидание происходило, поскольку не все ветви кода вызывали SetException/SetCanceled)

- Продублировал изменения в перегруженный метод TryInvokeMethodAsync(Action)
