### PR TITLE
#689 Исправлены конструкторы для некоторых Exceptions

### DIFF
--- a/VkNet/Exception/AppKeyInvalidException.cs
+++ b/VkNet/Exception/AppKeyInvalidException.cs
@@ -12,8 +12,9 @@ namespace VkNet.Exception
 	public class AppKeyInvalidException : VkApiMethodInvokeException
 	{
 		/// <inheritdoc />
-		public AppKeyInvalidException(VkResponse error) : base(message: error)
+		public AppKeyInvalidException(VkResponse response) : base(message: response[key: "error_msg"])
 		{
+			ErrorCode = response[key: "error_code"];
 		}
 	}
 }

--- a/VkNet/Exception/GroupKeyInvalidException.cs
+++ b/VkNet/Exception/GroupKeyInvalidException.cs
@@ -14,6 +14,7 @@ namespace VkNet.Exception
 		/// <inheritdoc />
 		public GroupKeyInvalidException(VkResponse response) : base(message: response[key: "error_msg"])
 		{
+			ErrorCode = response[key: "error_code"];
 		}
 	}
 }


### PR DESCRIPTION
## Список изменений
- Исправлены конструкторы для AppKeyInvalidException, GroupKeyInvalidException.
Они выбрасывали исключения т.к. в конструктор наследуемого класса приходил объект вместо строки.
