### PR TITLE
Добавил дополнительную проверку

### DIFF
--- a/VkNet.Tests/Utils/VkResponseTests.cs
+++ b/VkNet.Tests/Utils/VkResponseTests.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using VkNet.Utils;
+
+namespace VkNet.Tests.Utils
+{
+	public class VkResponseTests
+	{
+		[Test]
+		public void ShouldBeNull()
+		{
+			const string json = @"{
+									'nullable_field': null,
+								}";
+
+			var jObject = JToken.Parse(json);
+			var response = new VkResponse(jObject) { RawJson = json };
+
+			Assert.IsNull((bool?) response["nullable_field"]);
+			Assert.IsNull((bool?) response["nonexistent_field"]);
+		}
+	}
+}

--- a/VkNet/Utils/VkResponse.cs
+++ b/VkNet/Utils/VkResponse.cs
@@ -48,7 +48,9 @@ namespace VkNet.Utils
 
 				var token = _token[key: key];
 
-				return token != null ? new VkResponse(token: _token[key: key]) : null;
+				return token != null && token.Type != JTokenType.Null
+					? new VkResponse(token)
+					: null;
 			}
 		}
 


### PR DESCRIPTION
## Список изменений
- Добавил дополнительную проверку. 
Проверки на `null` недостаточно, т.к. `token` будет равен `null` только если поле не существует. Это  вызывало проблемы при десериализация `nullable bool` свойств. 
Например, при десериализации такого Json:

  ```json
  {
    "nullable_field": null
  }
  ```
  в `bool?` выбрасывался `System.ArgumentException: Can not convert Null to Int32.` Т.к. после недостаточной проверки инициализировался пустой `VkResponse`.