### PR TITLE
 #710 Обновил RestClient для лучшего контроля частоты запросов

### DIFF
--- a/VkNet.Tests/VkApiTest.cs
+++ b/VkNet.Tests/VkApiTest.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using VkNet.Enums;
@@ -30,19 +28,16 @@ namespace VkNet.Tests
 		[Test]
 		public void Call_NotMoreThen3CallsPerSecond()
 		{
+			Url = "https://api.vk.com/method/friends.getRequests";
 			Json = @"{ ""response"": 2 }";
 			Api.RequestsPerSecond = 3; // Переопределение значения в базовом классе
-
-			Mock.Get(Api.RestClient)
-				.Setup(m =>
-					m.PostAsync(It.IsAny<Uri>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()))
-				.Returns(Task.FromResult(HttpResponse<string>.Success(HttpStatusCode.OK, Json, Url)));
+			SetupIRestClient(Mock.Get(Api.RestClient));
 
 			var start = DateTimeOffset.Now;
 
 			while (true)
 			{
-				Api.Call("someMethod", VkParameters.Empty, true);
+				Api.Call("friends.getRequests", VkParameters.Empty, true);
 
 				var total = (int) (DateTimeOffset.Now - start).TotalMilliseconds;
 

--- a/VkNet/Abstractions/Utils/IRestClient.cs
+++ b/VkNet/Abstractions/Utils/IRestClient.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
-using VkNet.Utils;
 
 namespace VkNet.Abstractions.Utils
 {
@@ -28,7 +28,7 @@ namespace VkNet.Abstractions.Utils
 		/// <param name="uri"> Uri </param>
 		/// <param name="parameters"> </param>
 		/// <returns> String result </returns>
-		Task<HttpResponse<string>> GetAsync(Uri uri, VkParameters parameters);
+		Task<HttpResponseMessage> GetAsync(Uri uri, IEnumerable<KeyValuePair<string, string>> parameters);
 
 		/// <summary>
 		/// POST запрос
@@ -36,6 +36,6 @@ namespace VkNet.Abstractions.Utils
 		/// <param name="uri"> Uri </param>
 		/// <param name="parameters"> Параметры </param>
 		/// <returns> Строковый результат </returns>
-		Task<HttpResponse<string>> PostAsync(Uri uri, IEnumerable<KeyValuePair<string, string>> parameters);
+		Task<HttpResponseMessage> PostAsync(Uri uri, IEnumerable<KeyValuePair<string, string>> parameters);
 	}
 }


### PR DESCRIPTION
Заменил в RestClient `PostAsync` и `GetAsync` на [`SendAsync`](https://docs.microsoft.com/ru-ru/dotnet/api/system.net.http.httpclient.sendasync?view=netframework-4.7.2#System_Net_Http_HttpClient_SendAsync_System_Net_Http_HttpRequestMessage_System_Net_Http_HttpCompletionOption_) с [`HttpCompletionOption.ResponseHeadersRead`](https://docs.microsoft.com/ru-ru/dotnet/api/system.net.http.httpcompletionoption?view=netframework-4.7.2). 
Эти методы возвращают результат только после считывания всего ответа, что приводило к долгой блокировке `_expireTimerLock` при тяжёлых запросах или `long poll` запросах.
https://github.com/vknet/vk/blob/2c0015c83a784eb8a6b75927b84b8a958d70e8d7/VkNet/VkApi.cs#L666