### PR TITLE
Починил сборку проекта

### DIFF
--- a/VkNet/VkNet.csproj
+++ b/VkNet/VkNet.csproj
@@ -64,7 +64,7 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
 		<PackageReference Include="Microsoft.Bcl" Version="1.1.10" />
 		<PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
-		<PackageReference Include="Microsoft.Bcl.Build" Version="1.0.21" />
+		<PackageReference Include="Microsoft.Bcl.Build" Version="1.0.21" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
 		<PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
 		<PackageReference Include="NetFx.Extensions.Logging.Abstractions" Version="2.1.1" />
 		<PackageReference Include="NetFx.Extensions.DependencyInjection" Version="2.1.1" />


### PR DESCRIPTION
`dotnet build` падал с ошибкой 

> Невозможно загрузить задачу "EnsureBindingRedirects" из сборки "...\.nuget\packages\microsoft.bcl.build\1.0.21\build\Microsoft.Bcl.Build.Tasks.dll". Could not load file or assembly 'Microsoft.Build.Utilities.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Не удается найти указанный файл. Проверьте правильность объявления <UsingTask>, доступность сборки со всеми ее зависимостями и наличие в задаче общего класса, реализующего Microsoft.Build.Framework.ITask.