### PR TITLE
Исправление issue #743

### DIFF
--- a/VkNet/Model/Attachments/PollBackgroundPoint.cs
+++ b/VkNet/Model/Attachments/PollBackgroundPoint.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using VkNet.Utils;
 
 namespace VkNet.Model.Attachments
@@ -42,6 +42,11 @@ namespace VkNet.Model.Attachments
 		/// </returns>
 		public static implicit operator PollBackgroundPoint(VkResponse response)
 		{
+			if (response == null)
+			{
+				return null;
+			}
+
 			return response.HasToken()
 				? FromJson(response)
 				: null;

--- a/VkNet/Utils/VkResponseEx.cs
+++ b/VkNet/Utils/VkResponseEx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -108,7 +108,7 @@ namespace VkNet.Utils
 				return new ReadOnlyCollection<T>(new List<T>());
 			}
 
-			return responseArray.Cast<T>().Select(x => x).Where(i => i != null).ToReadOnlyCollection();
+			return responseArray.Select(x => x as T).Where(i => i != null).ToReadOnlyCollection();
 		}
 
 		/// <summary>


### PR DESCRIPTION
Поскольку Cast<T> просто выполняет generic cast, компилятор не знает о операторе, и поэтому он игнорируется. Результат: ошибка как в issue #743 

Источник: https://stackoverflow.com/questions/13316718/explicit-implicit-cast-operator-fails-when-using-linqs-cast-operator