### PR TITLE
Исправил возможность построить пустую клавиатуру, удалить установленную клавиатуру в чате

### DIFF
--- a/VkNet/Model/Keyboard/IKeyboardBuilder.cs
+++ b/VkNet/Model/Keyboard/IKeyboardBuilder.cs
@@ -33,6 +33,12 @@ namespace VkNet.Model.Keyboard
 		IKeyboardBuilder SetOneTime();
 
 		/// <summary>
+		/// Удалить все добавленные кнопки и строки из клавиатуры
+		/// </summary>
+		/// <returns>Конструктор клавиатур</returns>
+		IKeyboardBuilder RemoveButtonsAndLines();
+
+		/// <summary>
 		/// Построить
 		/// </summary>
 		/// <returns>Клавиатура</returns>

--- a/VkNet/Model/Keyboard/IKeyboardBuilder.cs
+++ b/VkNet/Model/Keyboard/IKeyboardBuilder.cs
@@ -36,7 +36,7 @@ namespace VkNet.Model.Keyboard
 		/// Удалить все добавленные кнопки и строки из клавиатуры
 		/// </summary>
 		/// <returns>Конструктор клавиатур</returns>
-		IKeyboardBuilder RemoveButtonsAndLines();
+		IKeyboardBuilder Clear();
 
 		/// <summary>
 		/// Построить

--- a/VkNet/Model/Keyboard/KeyboardBuilder.cs
+++ b/VkNet/Model/Keyboard/KeyboardBuilder.cs
@@ -78,9 +78,22 @@ namespace VkNet.Model.Keyboard
 		}
 
 		/// <inheritdoc />
+		public IKeyboardBuilder RemoveButtonsAndLines()
+		{
+			_currentLine.Clear();
+			_fullKeyboard.ForEach(x=>x.Clear());
+			_fullKeyboard.Clear();
+
+			return this;
+		}
+
+		/// <inheritdoc />
 		public MessageKeyboard Build()
 		{
-			_fullKeyboard.Add(_currentLine);
+			if (_currentLine.Count != 0)
+			{
+				_fullKeyboard.Add(_currentLine);
+			}
 
 			return new MessageKeyboard
 			{

--- a/VkNet/Model/Keyboard/KeyboardBuilder.cs
+++ b/VkNet/Model/Keyboard/KeyboardBuilder.cs
@@ -78,7 +78,7 @@ namespace VkNet.Model.Keyboard
 		}
 
 		/// <inheritdoc />
-		public IKeyboardBuilder RemoveButtonsAndLines()
+		public IKeyboardBuilder Clear()
 		{
 			_currentLine.Clear();
 			_fullKeyboard.ForEach(x=>x.Clear());


### PR DESCRIPTION
## Список изменений
- Поправил метод Build класса MessageKeyboard. теперь он проверяет количество добавленных кнопок в текущей строке, с целью не добавлять лишнюю строку в _fullKeyboard. 

- Добавлен метод Clear, который удаляет строки кнопок и кнопки, что бы можно было очистить существующий KeyboardBuilder, не создавая нового.

Причина исправления: На данный момент, при построении клавиатуры всегда добавляется новая строка, а это значит, что после сериализации в json, массив кнопок будет иметь следующий вид: "buttons":[[]]. 
В этом случае клавиатура не убирается, а вк возвращает ошибку. Дело в том, что в соответствии с [документацией ](https://vk.com/dev/bots_docs_3?f=4.3.%2B%D0%9E%D1%82%D0%BF%D1%80%D0%B0%D0%B2%D0%BA%D0%B0%2B%D0%BA%D0%BB%D0%B0%D0%B2%D0%B8%D0%B0%D1%82%D1%83%D1%80%D1%8B) vk api, необходимо отправить пустой массив строк для кнопок("buttons":[]),что бы удалить клавиатуру.

Данный пул-реквест устраняет проблему, добавляя возможность удалить установленную клавиатуру посредством построения пустой клавиатуры.