### PR TITLE
Исправить ошибку InvalidOperationException

### DIFF
--- a/VkNet/Utils/RestClient.cs
+++ b/VkNet/Utils/RestClient.cs
@@ -19,8 +19,6 @@ namespace VkNet.Utils
 
 		private readonly ILogger<RestClient> _logger;
 
-		private TimeSpan _timeoutSeconds;
-
 		/// <inheritdoc />
 		public RestClient(HttpClient httpClient, ILogger<RestClient> logger)
 		{
@@ -33,11 +31,8 @@ namespace VkNet.Utils
 		public IWebProxy Proxy { get; set; }
 
 		/// <inheritdoc />
-		public TimeSpan Timeout
-		{
-			get => _timeoutSeconds == TimeSpan.Zero ? TimeSpan.FromSeconds(300) : _timeoutSeconds;
-			set => _timeoutSeconds = value;
-		}
+		[Obsolete("Use HttpClientFactory to configure timeout.")]
+		public TimeSpan Timeout { get; set; }
 
 		/// <inheritdoc />
 		public Task<HttpResponse<string>> GetAsync(Uri uri, IEnumerable<KeyValuePair<string, string>> parameters)
@@ -76,8 +71,6 @@ namespace VkNet.Utils
 
 		private async Task<HttpResponse<string>> CallAsync(Func<HttpClient, Task<HttpResponseMessage>> method)
 		{
-			_httpClient.Timeout = Timeout;
-
 			var response = await method(_httpClient).ConfigureAwait(false);
 
 			var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
https://github.com/vknet/vk/blob/a1d74f092a560b4e3db891ecc7208216e6092d37/VkNet/Utils/RestClient.cs#L79
Установка таймаута во время запроса приводит к выбросу `InvalidOperationException`.