### PR TITLE
Обновил параметры запросов NewsFeed Category

### DIFF
--- a/VkNet.Tests/Categories/NewsFeedCategoryTest.cs
+++ b/VkNet.Tests/Categories/NewsFeedCategoryTest.cs
@@ -22,7 +22,7 @@ namespace VkNet.Tests.Categories
 
 			var result = Api.NewsFeed.Get(new NewsFeedGetParams
 			{
-				SourceIds = "1234"
+				SourceIds = new []{"1234"}
 			});
 
 			Assert.IsNotEmpty(result.Items);

--- a/VkNet/Enums/Filters/NewsTypes.cs
+++ b/VkNet/Enums/Filters/NewsTypes.cs
@@ -1,9 +1,9 @@
-﻿namespace VkNet.Enums.SafetyEnums
+﻿namespace VkNet.Enums.Filters
 {
 	/// <summary>
 	/// Названия списков новостей, которые необходимо получить.
 	/// </summary>
-	public sealed class NewsTypes : SafetyEnum<NewsTypes>
+	public sealed class NewsTypes : MultivaluedFilter<NewsTypes>
 	{
 		/// <summary>
 		/// Новые записи со стен.

--- a/VkNet/Model/NewsItem.cs
+++ b/VkNet/Model/NewsItem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using VkNet.Enums.Filters;
 using VkNet.Enums.SafetyEnums;
 using VkNet.Model.Attachments;
 using VkNet.Utils;

--- a/VkNet/Model/RequestParams/NewsFeed/NewsFeedGetCommentsParams.cs
+++ b/VkNet/Model/RequestParams/NewsFeed/NewsFeedGetCommentsParams.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using VkNet.Enums.SafetyEnums;
+using VkNet.Enums.Filters;
 using VkNet.Utils;
 using VkNet.Utils.JsonConverter;
 

--- a/VkNet/Model/RequestParams/NewsFeed/NewsFeedGetParams.cs
+++ b/VkNet/Model/RequestParams/NewsFeed/NewsFeedGetParams.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using VkNet.Enums.Filters;
@@ -67,7 +68,7 @@ namespace VkNet.Model.RequestParams
 		/// групп пользователя, за исключением
 		/// скрытых источников, которые можно получить методом newsfeed.getBanned.  строка.
 		/// </summary>
-		public string SourceIds { get; set; }
+		public IEnumerable<string> SourceIds { get; set; }
 
 		/// <summary>
 		/// Идентификатор, необходимый для получения следующей страницы результатов.
@@ -85,7 +86,7 @@ namespace VkNet.Model.RequestParams
 		/// <summary>
 		/// Список дополнительных полей профилей и сообществ, которые необходимо вернуть.
 		/// </summary>
-		public string Fields { get; set; }
+		public IEnumerable<string> Fields { get; set; }
 
 		/// <summary>
 		/// Привести к типу VkParameters.

--- a/VkNet/Model/RequestParams/NewsFeed/NewsFeedGetParams.cs
+++ b/VkNet/Model/RequestParams/NewsFeed/NewsFeedGetParams.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using VkNet.Enums.SafetyEnums;
+using VkNet.Enums.Filters;
 using VkNet.Utils;
 using VkNet.Utils.JsonConverter;
 


### PR DESCRIPTION
## Список изменений
- `NewsTypes` унаследован от `MultivaluedFilter`, потому что в `newsfeed.get` в параметре `filters` может находиться несколько значений. `SafetyEnum` не позволяет этого сделать.
- Типы свойств `SourceIds`, `Fields` класса `NewsFeedGetParams`  изменены на `IEnumerable<string>`
