### PR TITLE
Исправление метода stats.get

### DIFF
--- a/VkNet/Model/StatsGetParams.cs
+++ b/VkNet/Model/StatsGetParams.cs
@@ -34,7 +34,7 @@ namespace VkNet.Model
 		/// </remarks>
 		[JsonProperty("timestamp_from")]
 		[JsonConverter(typeof(UnixDateTimeConverter))]
-		public DateTime TimestampFrom { get; set; }
+		public DateTime? TimestampFrom { get; set; }
 
 		/// <summary>
 		/// Окончание периода статистики в Unixtime.
@@ -44,7 +44,7 @@ namespace VkNet.Model
 		/// </remarks>
 		[JsonProperty("timestamp_to")]
 		[JsonConverter(typeof(UnixDateTimeConverter))]
-		public DateTime TimestampTo { get; set; }
+		public DateTime? TimestampTo { get; set; }
 
 		/// <summary>
 		/// Временные интервалы.


### PR DESCRIPTION
Исправление метода stats.get. Дело в том, что в StatsGetParams свойства TimestampFrom и TimestampTo имели тип DateTime, а не Nullable<DateTime> . В время создание параметров запроса внутри библиотеки, TimestampFrom превращался в обычную строку вида "05.02.2019 22:14:21", а не в формате Unix. Так же, для вызова этого метода не обязательно заполнять поляTimestampFrom и TimestampTo