### PR TITLE
remove support for old .net frameworks

### DIFF
--- a/VkNet.Core.Abstractions/VkNet.Core.Abstractions.csproj
+++ b/VkNet.Core.Abstractions/VkNet.Core.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net40;net45;netstandard2.0</TargetFrameworks>
 		<NetStandardImplicitPackageVersion>2.0</NetStandardImplicitPackageVersion>
+		<TargetFramework>netstandard2.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/VkNet/VkNet.csproj
+++ b/VkNet/VkNet.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net40;net45;net461;netstandard2.0</TargetFrameworks>
 		<AssemblyName>VkNet</AssemblyName>
 		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 		<GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -37,6 +36,7 @@
 			Список изменений: http://bit.ly/2GbC1eR
 		</PackageReleaseNotes>
 		<LangVersion>latest</LangVersion>
+		<TargetFramework>netstandard2.0</TargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;UWP</DefineConstants>

--- a/VkNet/VkNet.csproj
+++ b/VkNet/VkNet.csproj
@@ -12,7 +12,7 @@
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<VersionPrefix>1.44.0</VersionPrefix>
+		<VersionPrefix>2.0.0</VersionPrefix>
 		<VersionSufix>
 		</VersionSufix>
 		<NeutralLanguage>ru-RU</NeutralLanguage>


### PR DESCRIPTION
## Список изменений
- выкинул поддержку старых .net framework-ов. Теперь в списке поддерживаемых такие: .net core 2+, .net framework 4.6.1+