### PR TITLE
Удалить параметр skipAuthorization из методов категории Utils

### DIFF
--- a/VkNet/Abstractions/Category/Async/IUtilsCategoryAsync.cs
+++ b/VkNet/Abstractions/Category/Async/IUtilsCategoryAsync.cs
@@ -18,28 +18,24 @@ namespace VkNet.Abstractions
 		/// сайте ВКонтакте.
 		/// </summary>
 		/// <param name="url"> Внешняя ссылка, которую необходимо проверить. </param>
-		/// <param name="skipAuthorization"> Без авторизации </param>
 		/// <returns> Статус ссылки </returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/utils.checkLink
 		/// </remarks>
 		Task<LinkAccessType> CheckLinkAsync([NotNull]
-											string url
-											, bool skipAuthorization = true);
+											string url);
 
 		/// <summary>
 		/// Возвращает информацию о том, является ли внешняя ссылка заблокированной на
 		/// сайте ВКонтакте.
 		/// </summary>
 		/// <param name="url"> Внешняя ссылка, которую необходимо проверить. </param>
-		/// <param name="skipAuthorization"> Без авторизации </param>
 		/// <returns> Статус ссылки </returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/utils.checkLink
 		/// </remarks>
 		Task<LinkAccessType> CheckLinkAsync([NotNull]
-											Uri url
-											, bool skipAuthorization = true);
+											Uri url);
 
 		/// <summary>
 		/// Определяет тип объекта (пользователь, сообщество, приложение) и его

--- a/VkNet/Abstractions/Category/IUtilsCategory.cs
+++ b/VkNet/Abstractions/Category/IUtilsCategory.cs
@@ -17,24 +17,22 @@ namespace VkNet.Abstractions
 		/// сайте ВКонтакте.
 		/// </summary>
 		/// <param name="url"> Внешняя ссылка, которую необходимо проверить. </param>
-		/// <param name="skipAuthorization"> Без авторизации </param>
 		/// <returns> Статус ссылки </returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/utils.checkLink
 		/// </remarks>
-		LinkAccessType CheckLink([NotNull] string url, bool skipAuthorization = true);
+		LinkAccessType CheckLink([NotNull] string url);
 
 		/// <summary>
 		/// Возвращает информацию о том, является ли внешняя ссылка заблокированной на
 		/// сайте ВКонтакте.
 		/// </summary>
 		/// <param name="url"> Внешняя ссылка, которую необходимо проверить. </param>
-		/// <param name="skipAuthorization"> Без авторизации </param>
 		/// <returns> Статус ссылки </returns>
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/utils.checkLink
 		/// </remarks>
-		LinkAccessType CheckLink([NotNull] Uri url, bool skipAuthorization = true);
+		LinkAccessType CheckLink([NotNull] Uri url);
 
 		/// <summary>
 		/// Определяет тип объекта (пользователь, сообщество, приложение) и его

--- a/VkNet/Categories/Async/UtilsCategoryAsync.cs
+++ b/VkNet/Categories/Async/UtilsCategoryAsync.cs
@@ -11,15 +11,15 @@ namespace VkNet.Categories
 	public partial class UtilsCategory
 	{
 		/// <inheritdoc />
-		public Task<LinkAccessType> CheckLinkAsync(string url, bool skipAuthorization = true)
+		public Task<LinkAccessType> CheckLinkAsync(string url)
 		{
-			return TypeHelper.TryInvokeMethodAsync(func: () =>CheckLink(url: url, skipAuthorization: skipAuthorization));
+			return TypeHelper.TryInvokeMethodAsync(func: () =>CheckLink(url: url));
 		}
 
 		/// <inheritdoc />
-		public Task<LinkAccessType> CheckLinkAsync(Uri url, bool skipAuthorization = true)
+		public Task<LinkAccessType> CheckLinkAsync(Uri url)
 		{
-			return TypeHelper.TryInvokeMethodAsync(func: () =>CheckLink(url: url, skipAuthorization: skipAuthorization));
+			return TypeHelper.TryInvokeMethodAsync(func: () =>CheckLink(url: url));
 		}
 
 		/// <inheritdoc />

--- a/VkNet/Categories/UtilsCategory.cs
+++ b/VkNet/Categories/UtilsCategory.cs
@@ -25,21 +25,21 @@ namespace VkNet.Categories
 
 		/// <inheritdoc />
 		[Pure]
-		public LinkAccessType CheckLink(string url, bool skipAuthorization = true)
+		public LinkAccessType CheckLink(string url)
 		{
-			return CheckLink(new Uri(uriString: url), skipAuthorization);
+			return CheckLink(new Uri(uriString: url));
 		}
 
 		/// <inheritdoc />
 		[Pure]
-		public LinkAccessType CheckLink(Uri url, bool skipAuthorization = true)
+		public LinkAccessType CheckLink(Uri url)
 		{
 			var parameters = new VkParameters
 			{
 				{ "url", url }
 			};
 
-			return _vk.Call("utils.checkLink", parameters, skipAuthorization);
+			return _vk.Call("utils.checkLink", parameters);
 		}
 
 		/// <inheritdoc />
@@ -53,14 +53,14 @@ namespace VkNet.Categories
 				{ "screen_name", screenName }
 			};
 
-			return _vk.Call("utils.resolveScreenName", parameters, true);
+			return _vk.Call("utils.resolveScreenName", parameters);
 		}
 
 		/// <inheritdoc />
 		[Pure]
 		public DateTime GetServerTime()
 		{
-			return _vk.Call<DateTime>("utils.getServerTime", VkParameters.Empty, true);
+			return _vk.Call<DateTime>("utils.getServerTime", VkParameters.Empty);
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
## Список изменений
- Удалён параметр skipAuthorization из методов категории Utils, так как эти методы обязательно требуют авторизации

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
