### PR TITLE
Исправлена ошибка с полем Occupation_Id

### DIFF
--- a/VkNet/Model/Occupation.cs
+++ b/VkNet/Model/Occupation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using VkNet.Enums.SafetyEnums;
 using VkNet.Utils;
@@ -20,7 +20,7 @@ namespace VkNet.Model
 		/// <summary>
 		/// Идентификатор школы, вуза, группы компании (в которой пользователь работает).
 		/// </summary>
-		public long Id { get; set; }
+		public long? Id { get; set; }
 
 		/// <summary>
 		/// Информация о текущем роде занятия пользователя.


### PR DESCRIPTION
Исправлена ошибка с полем Occupation_Id. Несмотря на документацию оно может быть не указано и соответственно в этом случае при загрузке блока Occupation методом users.get будет ошибка.
Пример страницы при загрузке которой происходит ошибка
https://vk.com/olgabuzova

## Список изменений
- Изменение 1

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
