### PR TITLE
Update Browser.Async.cs

### DIFF
--- a/VkNet/Utils/Async/Browser.Async.cs
+++ b/VkNet/Utils/Async/Browser.Async.cs
@@ -17,6 +17,7 @@ namespace VkNet.Utils
 		/// <inheritdoc />
 		public async Task<AuthorizationResult> AuthorizeAsync()
 		{
+			LoginPasswordError = 0;
 			var authorizeUrlResult = await OpenAuthDialogAsync().ConfigureAwait(false);
 
 			return await NextStepAsync(authorizeUrlResult).ConfigureAwait(false);


### PR DESCRIPTION
При каждой попытке авторизации нужно сбрасывать счётчик ошибок LoginPasswordError
Иначе в случае когда объект VkApi вызывает метод RefreshToken, в момент истечения срока жизни предыдущего токена, будет происходить ошибка throw new VkAuthorizationException("Неверный логин или пароль.");
Такой сценарий легко получить установив объект VkApi как синглтон в приложении и обновляя токен раз в сутки. (или просто вызвав метод RefreshToken на объекте VkApi уже прошедшем авторизацию)

## Список изменений
- Изменение 1

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
