### PR TITLE
Реализовать поля transcript и transcript_state в audio_message #1017

### DIFF
--- a/VkNet.Tests/Enum/SafetyEnums/SafetyEnumTests.cs
+++ b/VkNet.Tests/Enum/SafetyEnums/SafetyEnumTests.cs
@@ -861,5 +861,16 @@ namespace VkNet.Tests.Enum.SafetyEnums
 			Assert.That(AppWidgetType.FromJsonString("compact_list"), Is.EqualTo(AppWidgetType.CompactList));
 			Assert.That(AppWidgetType.FromJsonString("cover_list"), Is.EqualTo(AppWidgetType.CoverList));
 		}
+
+		[Test]
+		public void TranscriptStatesTest()
+		{
+			// get test
+			Assert.That(TranscriptStates.Done.ToString(), Is.EqualTo("done"));
+			Assert.That(TranscriptStates.InProgress.ToString(), Is.EqualTo("in_progress"));
+			// parse test
+			Assert.That(TranscriptStates.FromJsonString("done"), Is.EqualTo(TranscriptStates.Done));
+			Assert.That(TranscriptStates.FromJsonString("in_progress"), Is.EqualTo(TranscriptStates.InProgress));
+		}
 	}
 }

--- a/VkNet.Tests/Models/AudioMessageModel.cs
+++ b/VkNet.Tests/Models/AudioMessageModel.cs
@@ -1,12 +1,14 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
+using VkNet.Enums.SafetyEnums;
 using VkNet.Model.Attachments;
 
 namespace VkNet.Tests.Models
 {
 	[TestFixture]
 	[ExcludeFromCodeCoverage]
-	public class AudioMessageModel
+	public class AudioMessageModel : BaseTest
 	{
 		[Test]
 		public void ToString_AudioMessageShouldHaveAccessKey()
@@ -21,6 +23,41 @@ namespace VkNet.Tests.Models
 			var result = audioMessage.ToString();
 
 			Assert.AreEqual(result, "audio_message1234_1234_test");
+		}
+
+		[Test]
+		public void ShouldDeserializeFromVkResponseToAudioMessageWithTranscript()
+		{
+			ReadJsonFile("Models", "audio_message_with_transcription");
+
+			var response = GetResponse();
+
+			var attachment = Attachment.FromJson(response);
+			Assert.True(attachment.Instance is AudioMessage);
+
+			var audioMessage = attachment.Instance as AudioMessage;
+			Assert.That(audioMessage.Duration, Is.EqualTo(25));
+			Assert.That(audioMessage.LinkOgg, Is.EqualTo(new Uri("https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.ogg")));
+			Assert.That(audioMessage.LinkMp3, Is.EqualTo(new Uri("https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.mp3")));
+			Assert.That(audioMessage.Transcript, Is.EqualTo("demo message"));
+			Assert.That(audioMessage.TranscriptState, Is.EqualTo(TranscriptStates.Done));
+		}
+
+		[Test]
+		public void ShouldDeserializeFromVkResponseToAudioMessage()
+		{
+			ReadJsonFile("Models", "audio_message_without_transcription");
+
+			var response = GetResponse();
+
+			var attachment = Attachment.FromJson(response);
+			Assert.True(attachment.Instance is AudioMessage);
+
+			var audioMessage = attachment.Instance as AudioMessage;
+			Assert.That(audioMessage.Duration, Is.EqualTo(25));
+			Assert.That(audioMessage.LinkOgg, Is.EqualTo(new Uri("https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.ogg")));
+			Assert.That(audioMessage.LinkMp3, Is.EqualTo(new Uri("https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.mp3")));
+			Assert.That(audioMessage.Transcript, Is.EqualTo(null));
 		}
 	}
 }

--- a/VkNet.Tests/TestData/Models/audio_message_with_transcription.json
+++ b/VkNet.Tests/TestData/Models/audio_message_with_transcription.json
@@ -1,0 +1,16 @@
+{
+    "type": "audio_message",
+    "audio_message": {
+        "id": 123456789,
+        "owner_id": 987655443,
+        "duration": 25,
+        "waveform": [
+            0, 0, 1, 31, 26, 8, 2, 4, 5, 1, 2, 2, 2, 3, 1, 6, 10
+        ],
+        "link_ogg": "https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.ogg",
+        "link_mp3": "https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.mp3",
+        "access_key": "d11e675f1ef73c0375",
+        "transcript": "demo message",
+        "transcript_state": "done"
+    }
+}

--- a/VkNet.Tests/TestData/Models/audio_message_without_transcription.json
+++ b/VkNet.Tests/TestData/Models/audio_message_without_transcription.json
@@ -1,0 +1,14 @@
+{
+    "type": "audio_message",
+    "audio_message": {
+        "id": 123456789,
+        "owner_id": 987655443,
+        "duration": 25,
+        "waveform": [
+            0, 0, 1, 31, 26, 8, 2, 4, 5, 1, 2, 2, 2, 3, 1, 6, 10
+        ],
+        "link_ogg": "https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.ogg",
+        "link_mp3": "https://psv4.userapi.com/c205420//u111874665/audiomsg/d12/794c8440a8.mp3",
+        "access_key": "d11e675f1ef73c0375"
+    }
+}

--- a/VkNet/Enums/SafetyEnums/TranscriptStates.cs
+++ b/VkNet/Enums/SafetyEnums/TranscriptStates.cs
@@ -1,0 +1,18 @@
+﻿namespace VkNet.Enums.SafetyEnums
+{
+	/// <summary>
+	/// Статус транскрипции голосового сообщения
+	/// </summary>
+	public sealed class TranscriptStates : SafetyEnum<TranscriptStates>
+	{
+		/// <summary>
+		/// Транскрипция в обработке
+		/// </summary>
+		public static readonly TranscriptStates InProgress = RegisterPossibleValue(value: "in_progress");
+
+		/// <summary>
+		/// Транскрипция завершена
+		/// </summary>
+		public static readonly TranscriptStates Done = RegisterPossibleValue(value: "done");
+	}
+}

--- a/VkNet/Model/Attachments/AudioMessage.cs
+++ b/VkNet/Model/Attachments/AudioMessage.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.ObjectModel;
 using Newtonsoft.Json;
+using VkNet.Enums.SafetyEnums;
 using VkNet.Utils;
+using VkNet.Utils.JsonConverter;
 
 namespace VkNet.Model.Attachments
 {
@@ -39,6 +41,19 @@ namespace VkNet.Model.Attachments
 		public Uri LinkMp3 { get; set; }
 
 		/// <summary>
+		/// Текст транскрипции
+		/// </summary>
+		[JsonProperty("transcript")]
+		public string Transcript { get; set; }
+
+		/// <summary>
+		/// Статус транскрипции
+		/// </summary>
+		[JsonProperty("transcript_state")]
+		[JsonConverter(typeof(SafetyEnumJsonConverter))]
+		public TranscriptStates TranscriptState { get; set; }
+
+		/// <summary>
 		/// Разобрать из json.
 		/// </summary>
 		/// <param name="response"> Ответ сервера. </param>
@@ -53,7 +68,9 @@ namespace VkNet.Model.Attachments
 				Waveform = response["waveform"].ToReadOnlyCollectionOf<int>(x => x),
 				LinkOgg = response["link_ogg"],
 				LinkMp3 = response["link_mp3"],
-				AccessKey = response["access_key"]
+				AccessKey = response["access_key"],
+				Transcript = response["transcript"],
+				TranscriptState = response["transcript_state"]
 			};
 		}
 

--- a/VkNet/Utils/VkResponseToSafetyEnumCastGenerator.cs
+++ b/VkNet/Utils/VkResponseToSafetyEnumCastGenerator.cs
@@ -736,5 +736,17 @@ namespace VkNet.Utils
 		{
 			return response == null ? null : IdsType.FromJson(response: response);
 		}
+
+		/// <summary>
+		/// Преобразовать из VkResponse
+		/// </summary>
+		/// <param name="response"> Ответ. </param>
+		/// <returns>
+		/// Результат преобразования.
+		/// </returns>
+		public static implicit operator TranscriptStates(VkResponse response)
+		{
+			return response == null ? null : TranscriptStates.FromJson(response: response);
+		}
 	}
 }


### PR DESCRIPTION
## Список изменений
- Добавлен класс `TranscriptStates`, который содержит статусы транскрипции голосового сообщения
- Добавлены поля `transcript` и `transcript_state` в `AudioMessage`

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
