### PR TITLE
Фикс KeyboardBuilder.Clear

### DIFF
--- a/VkNet/Model/Keyboard/KeyboardBuilder.cs
+++ b/VkNet/Model/Keyboard/KeyboardBuilder.cs
@@ -130,6 +130,7 @@ namespace VkNet.Model.Keyboard
 		{
 			_currentLine.Clear();
 			_fullKeyboard.Clear();
+			_totalPayloadLength = 0;
 
 			return this;
 		}


### PR DESCRIPTION
KeyboardBuilder._totalPayloadLength теперь обнуляется.
