### PR TITLE
#1002 переименовать методы Account.BanUser и Account.UnbanUser

### DIFF
--- a/VkNet.Tests/Categories/Account/AccountCategoryTest.cs
+++ b/VkNet.Tests/Categories/Account/AccountCategoryTest.cs
@@ -30,7 +30,7 @@ namespace VkNet.Tests.Categories.Account
 		[Test]
 		public void BanUser_CorrectParameters_ReturnFalse()
 		{
-			Url = "https://api.vk.com/method/account.banUser";
+			Url = "https://api.vk.com/method/account.ban";
 			ReadJsonFile(JsonPaths.False);
 			Assert.That(Api.Account.BanUser(1), Is.False); // Нельзя просто так взять и забанить Дурова
 		}
@@ -38,7 +38,7 @@ namespace VkNet.Tests.Categories.Account
 		[Test]
 		public void BanUser_CorrectParameters_ReturnTrue()
 		{
-			Url = "https://api.vk.com/method/account.banUser";
+			Url = "https://api.vk.com/method/account.ban";
 			ReadJsonFile(JsonPaths.True);
 			Assert.That(Api.Account.BanUser(4), Is.True);
 		}
@@ -664,7 +664,7 @@ namespace VkNet.Tests.Categories.Account
 		[Test]
 		public void UnbanUser_CorrectParameters_ReturnFalse()
 		{
-			Url = "https://api.vk.com/method/account.unbanUser";
+			Url = "https://api.vk.com/method/account.unban";
 			ReadJsonFile(JsonPaths.False);
 			Assert.That(Api.Account.UnbanUser(1), Is.False);
 		}
@@ -672,7 +672,7 @@ namespace VkNet.Tests.Categories.Account
 		[Test]
 		public void UnbanUser_CorrectParameters_ReturnTrue()
 		{
-			Url = "https://api.vk.com/method/account.unbanUser";
+			Url = "https://api.vk.com/method/account.unban";
 			ReadJsonFile(JsonPaths.True);
 			Assert.That(Api.Account.UnbanUser(4), Is.True);
 		}

--- a/VkNet/Abstractions/Category/Async/IAccountCategoryAsync.cs
+++ b/VkNet/Abstractions/Category/Async/IAccountCategoryAsync.cs
@@ -225,6 +225,9 @@ namespace VkNet.Abstractions
 		/// </remarks>
 		Task<InformationAboutOffers> GetActiveOffersAsync(ulong? offset = null, ulong? count = null);
 
+		/// <inheritdoc cref="BanAsync"/>
+		Task<bool> BanUserAsync(long ownerId);
+
 		/// <summary>
 		/// Добавляет пользователя в черный список.
 		/// </summary>
@@ -238,7 +241,10 @@ namespace VkNet.Abstractions
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/account.banUser
 		/// </remarks>
-		Task<bool> BanUserAsync(long ownerId);
+		Task<bool> BanAsync(long ownerId);
+
+		/// <inheritdoc cref="UnbanAsync"/>
+		Task<bool> UnbanUserAsync(long ownerId);
 
 		/// <summary>
 		/// Убирает пользователя из черного списка.
@@ -253,7 +259,7 @@ namespace VkNet.Abstractions
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/account.unbanUser
 		/// </remarks>
-		Task<bool> UnbanUserAsync(long ownerId);
+		Task<bool> UnbanAsync(long ownerId);
 
 		/// <summary>
 		/// Возвращает список пользователей, находящихся в черном списке.

--- a/VkNet/Abstractions/Category/IAccountCategory.cs
+++ b/VkNet/Abstractions/Category/IAccountCategory.cs
@@ -48,8 +48,14 @@ namespace VkNet.Abstractions
 		/// <inheritdoc cref="IAccountCategoryAsync.BanUserAsync"/>
 		bool BanUser(long ownerId);
 
+		/// <inheritdoc cref="IAccountCategoryAsync.BanUserAsync"/>
+		bool Ban(long ownerId);
+
 		/// <inheritdoc cref="IAccountCategoryAsync.UnbanUserAsync"/>
 		bool UnbanUser(long ownerId);
+
+		/// <inheritdoc cref="IAccountCategoryAsync.UnbanUserAsync"/>
+		bool Unban(long ownerId);
 
 		/// <inheritdoc cref="IAccountCategoryAsync.GetBannedAsync"/>
 		AccountGetBannedResult GetBanned(int? offset = null, int? count = null);

--- a/VkNet/Categories/AccountCategory.cs
+++ b/VkNet/Categories/AccountCategory.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using VkNet.Abstractions;
@@ -164,25 +165,39 @@ namespace VkNet.Categories
 		}
 
 		/// <inheritdoc />
+		[Obsolete(ObsoleteText.BanUser)]
 		public bool BanUser(long ownerId)
 		{
-			var parameters = new VkParameters
-			{
-				{ "owner_id", ownerId }
-			};
-
-			return _vk.Call("account.banUser", parameters);
+			return Ban(ownerId);
 		}
 
 		/// <inheritdoc />
-		public bool UnbanUser(long ownerId)
+		public bool Ban(long ownerId)
 		{
 			var parameters = new VkParameters
 			{
 				{ "owner_id", ownerId }
 			};
 
-			return _vk.Call("account.unbanUser", parameters);
+			return _vk.Call("account.ban", parameters);
+		}
+
+		/// <inheritdoc />
+		[Obsolete(ObsoleteText.UnbanUser)]
+		public bool UnbanUser(long ownerId)
+		{
+			return Unban(ownerId);
+		}
+
+		/// <inheritdoc />
+		public bool Unban(long ownerId)
+		{
+			var parameters = new VkParameters
+			{
+				{ "owner_id", ownerId }
+			};
+
+			return _vk.Call("account.unban", parameters);
 		}
 
 		/// <inheritdoc />

--- a/VkNet/Categories/Async/AccountCategoryAsync.cs
+++ b/VkNet/Categories/Async/AccountCategoryAsync.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,15 +81,29 @@ namespace VkNet.Categories
 		}
 
 		/// <inheritdoc />
+		[Obsolete(ObsoleteText.BanUserAsync)]
 		public Task<bool> BanUserAsync(long ownerId)
 		{
-			return TypeHelper.TryInvokeMethodAsync(() => BanUser(ownerId));
+			return BanAsync(ownerId);
 		}
 
 		/// <inheritdoc />
+		public Task<bool> BanAsync(long ownerId)
+		{
+			return TypeHelper.TryInvokeMethodAsync(() => Ban(ownerId));
+		}
+
+		/// <inheritdoc />
+		[Obsolete(ObsoleteText.UnbanUserAsync)]
 		public Task<bool> UnbanUserAsync(long ownerId)
 		{
-			return TypeHelper.TryInvokeMethodAsync(() => UnbanUser(ownerId));
+			return UnbanAsync(ownerId);
+		}
+
+		/// <inheritdoc />
+		public Task<bool> UnbanAsync(long ownerId)
+		{
+			return TypeHelper.TryInvokeMethodAsync(() => Unban(ownerId));
 		}
 
 		/// <inheritdoc />

--- a/VkNet/Utils/ObsoleteText.cs
+++ b/VkNet/Utils/ObsoleteText.cs
@@ -91,6 +91,26 @@ namespace VkNet.Utils
 		public const string FriendsAddList = Deprecated + "long AddList(string name, IEnumerable<long> userIds);";
 
 		/// <summary>
+		/// <inheritdoc cref="Deprecated"/> <see cref="IAccountCategory.Ban"/>
+		/// </summary>
+		public const string BanUser = Deprecated + "bool Ban(long ownerId);";
+
+		/// <summary>
+		/// <inheritdoc cref="Deprecated"/> <see cref="IAccountCategory.Unban"/>
+		/// </summary>
+		public const string UnbanUser = Deprecated + "bool Unban(long ownerId);";
+
+		/// <summary>
+		/// <inheritdoc cref="Deprecated"/> <see cref="IAccountCategory.BanAsync"/>
+		/// </summary>
+		public const string BanUserAsync = Deprecated + "bool BanAsync(long ownerId);";
+
+		/// <summary>
+		/// <inheritdoc cref="Deprecated"/> <see cref="IAccountCategory.UnbanAsync"/>
+		/// </summary>
+		public const string UnbanUserAsync = Deprecated + "bool UnbanAsync(long ownerId);";
+
+		/// <summary>
 		/// <inheritdoc cref="Obsolete"/> Используйте вместо него
 		/// </summary>
 		private const string Deprecated = Obsolete + " Используйте вместо него ";
@@ -100,7 +120,7 @@ namespace VkNet.Utils
 		/// </summary>
 		public const string Obsolete =
 			"Данный метод устарел и может быть отключён через некоторое время, пожалуйста, избегайте его использования.";
-		
+
 		/// <summary>
 		/// Данный класс устарел и может быть удалён в будующих версиях, пожалуйста, избегайте его использования.
 		/// </summary>


### PR DESCRIPTION
## Список изменений
- Добавлены методы `Account.Ban` и `Account.Unban`, а `Account.BanUser` и `Account.UnbanUser` помечены как `Obsolete`

Также методы теперь вызывают не `banUser` и `unbanUser`, а `ban` и `unban`
https://vk.com/dev/account.ban
https://vk.com/dev/account.unban

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
