### PR TITLE
#959 Скрыть токен и пароли при выводе JSON в логи

### DIFF
--- a/VkNet/Utils/Utilities.cs
+++ b/VkNet/Utils/Utilities.cs
@@ -97,9 +97,28 @@ namespace VkNet.Utils
 		/// <returns> Json </returns>
 		public static string PrettyPrintJson(string json)
 		{
+			const string hidden = "***HIDDEN***";
+
+			var keysToHide = new[]
+			{
+				"access_token",
+				"new_password",
+				"old_password"
+			};
+
 			try
 			{
-				return JToken.Parse(json).ToString(Formatting.Indented);
+				var jObject = JObject.Parse(json);
+
+				foreach (var key in keysToHide)
+				{
+					if (jObject.ContainsKey(key))
+					{
+						jObject[key] = hidden;
+					}
+				}
+
+				return jObject.ToString(Formatting.Indented);
 			}
 			catch (JsonReaderException)
 			{


### PR DESCRIPTION
## Список изменений
- Сделана замена `access_token`, `new_password` и `old_password` (из метода `account.changePassword`) на `***HIDDEN***`

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
