### PR TITLE
Fix for CountByIntervalAwaitableConstraint that changes the wait logic

### DIFF
--- a/VkNet.Tests/Utils/CountByIntervalAwaitableConstraintTests.cs
+++ b/VkNet.Tests/Utils/CountByIntervalAwaitableConstraintTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using VkNet.Enums;
+using VkNet.Model;
+using VkNet.Tests.Infrastructure;
+using VkNet.Utils;
+
+namespace VkNet.Tests.Utils
+{
+	public class CountByIntervalAwaitableConstraintTests
+	{
+		[Test]
+		public async Task WaitForReadinessAsync()
+		{
+			int count = 3;
+			var t = TimeSpan.FromSeconds(1);
+			var awaitableConstraint = new CountByIntervalAwaitableConstraint(count, t);
+			var token = new CancellationToken();
+			var sw = Stopwatch.StartNew();
+			for (int i = 0; i < count; i++)
+			{
+				await awaitableConstraint.WaitForReadinessAsync(token).ConfigureAwait(false);
+			}
+
+			await awaitableConstraint.WaitForReadinessAsync(token).ConfigureAwait(false);
+			var t2 = sw.Elapsed;
+			Assert.GreaterOrEqual(t2, t);
+		}
+	}
+}

--- a/VkNet.Tests/VkApiTest.cs
+++ b/VkNet.Tests/VkApiTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -36,18 +36,15 @@ namespace VkNet.Tests
 			Api.RequestsPerSecond = callsCount;
 
 			var taskList = new List<Task>();
+			var calls = 0;
 
 			for (var i = 0; i < callsCount + 1; i++)
 			{
-				taskList.Add(Api.CallAsync("friends.getRequests", VkParameters.Empty, true));
+				taskList.Add(Api.CallAsync("friends.getRequests", VkParameters.Empty, true).ContinueWith((_) => calls++));
 			}
 
-			Task.WhenAll(taskList);
-
 			await Task.Delay(1000);
-
-			Mock.Get(Api.RestClient)
-				.Verify(m => m.PostAsync(It.IsAny<Uri>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()), Times.AtMost(callsCount));
+			Assert.LessOrEqual(calls, callsCount);
 		}
 
 		[Test]


### PR DESCRIPTION
Fix for CountByIntervalAwaitableConstraint that changes the wait logic: wait only if requests exceed the maximum value per timeout.

## Список изменений
- Теперь мы ждем только если будет превышен лимит, в противном случае не будет ненужной задрежки, как это было раньше.

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [ ] Напишите тесты, и обязательно проверьте что не падают другие.

Следущий тест падает, как мне кажется, он не совсем правильный:

```c#
public async Task Call_NotMoreThen3CallsPerSecond()
{
  Url = "https://api.vk.com/method/friends.getRequests";
  ReadJsonFile(nameof(VkApi), nameof(Call_NotMoreThen3CallsPerSecond));
  const int callsCount = 3;
  Api.RequestsPerSecond = callsCount;
  
  var taskList = new List<Task>();
  
  for (var i = 0; i < callsCount + 1; i++)
  {
    taskList.Add(Api.CallAsync("friends.getRequests", VkParameters.Empty, true));
  }
  
  Task.WhenAll(taskList);
  
  await Task.Delay(1000);
  
  Mock.Get(Api.RestClient)
  .Verify(m => m.PostAsync(It.IsAny<Uri>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()), Times.AtMost(callsCount));
}
```
Мой тест проходит без ошибок:
```c#
public async Task Call_NotMoreThen3CallsPerSecond()
{
  Url = "https://api.vk.com/method/friends.getRequests";
  ReadJsonFile(nameof(VkApi), nameof(Call_NotMoreThen3CallsPerSecond));
  const int callsCount = 3;
  Api.RequestsPerSecond = callsCount;
  
  var taskList = new List<Task>();
  var calls = 0;
  
  for (var i = 0; i < callsCount + 1; i++)
  {
    taskList.Add(Api.CallAsync("friends.getRequests", VkParameters.Empty, true).ContinueWith((_) => calls++));
  }
  
  await Task.Delay(1000);
  Assert.LessOrEqual(calls, callsCount);
}
```