### PR TITLE
Исправлен баг с неправильной обработкой капчи при авторизации #1139

### DIFF
--- a/VkNet.Tests/Infrastructure/AuthorizationFormHtmlParserTests.cs
+++ b/VkNet.Tests/Infrastructure/AuthorizationFormHtmlParserTests.cs
@@ -38,6 +38,12 @@ namespace VkNet.Tests.Infrastructure
 			Assert.NotNull(result);
 			Assert.AreEqual("post", result.Method);
 			Assert.AreEqual("https://login.vk.com/?act=login&amp;soft=1&amp;utf8=1", result.Action);
+
+			Assert.IsNotNull(result.UrlToCaptcha);
+
+			var isCaptchaIndicated = result.UrlToCaptcha.Contains("captcha.php");
+			Assert.AreEqual(isCaptchaIndicated, true);
+
 			Assert.IsNotEmpty(result.Fields);
 		}
 

--- a/VkNet/Infrastructure/Authorization/ImplicitFlow/AuthorizationFormHtmlParser.cs
+++ b/VkNet/Infrastructure/Authorization/ImplicitFlow/AuthorizationFormHtmlParser.cs
@@ -47,12 +47,14 @@ namespace VkNet.Infrastructure.Authorization.ImplicitFlow
 			var inputs = ParseInputs(formNode);
 
 			var actionUrl = GetActionUrl(formNode, url);
+			var urlToCaptcha = GetUrlToCaptcha(doc);
 			var method = GetMethod(formNode);
 
 			return new VkHtmlFormResult
 			{
 				Fields = inputs,
 				Action = actionUrl,
+				UrlToCaptcha = urlToCaptcha,
 				Method = method
 			};
 		}
@@ -137,6 +139,24 @@ namespace VkNet.Infrastructure.Authorization.ImplicitFlow
 		private static string GetResponseBaseUrl(Uri uri)
 		{
 			return uri.Scheme + "://" + uri.Host + ":" + uri.Port;
+		}
+
+		/// <summary>
+		/// Возвращает URL для получения капчи
+		/// </summary>
+		/// <param name="document">HTML документ</param>
+		private static string GetUrlToCaptcha(HtmlDocument document)
+		{
+			var element = document.GetElementbyId("captcha");
+
+			if (element is null)
+			{
+				return null;
+			}
+
+			var urlToCaptcha = element.Attributes["src"];
+
+			return urlToCaptcha?.Value;
 		}
 	}
 }

--- a/VkNet/Infrastructure/Authorization/ImplicitFlow/Forms/ImplicitFlowCaptchaLoginForm.cs
+++ b/VkNet/Infrastructure/Authorization/ImplicitFlow/Forms/ImplicitFlowCaptchaLoginForm.cs
@@ -40,8 +40,7 @@ namespace VkNet.Infrastructure.Authorization.ImplicitFlow.Forms
 				form.Fields[AuthorizationFormFields.Password] = authParams.Password;
 			}
 
-			var captchaKey =
-				_captchaSolver.Solve($"https://api.vk.com//captcha.php?sid={form.Fields[AuthorizationFormFields.CaptchaSid]}&s=1");
+			var captchaKey = _captchaSolver.Solve(form.UrlToCaptcha);
 
 			if (form.Fields.ContainsKey(AuthorizationFormFields.CaptchaKey))
 			{

--- a/VkNet/Infrastructure/Authorization/ImplicitFlow/VkHtmlFormResult.cs
+++ b/VkNet/Infrastructure/Authorization/ImplicitFlow/VkHtmlFormResult.cs
@@ -18,6 +18,11 @@ namespace VkNet.Infrastructure.Authorization.ImplicitFlow
 		public string Action { get; set; }
 
 		/// <summary>
+		/// URL для получения капчи, если это необходимо
+		/// </summary>
+		public string UrlToCaptcha { get; set; }
+
+		/// <summary>
 		/// Поля формы
 		/// </summary>
 		public Dictionary<string, string> Fields { get; set; }


### PR DESCRIPTION
Баг возникал из-за того, что разработчики VK API в запросе к ВКонтакте для получения капчи параметр "s=1"  заменили на "dif=1". Теперь даже в случае изменения параметров запроса со стороны ВКонтакте баг не должен появляться.

## Список изменений
1. В VkHtmlFormResult добавлено новое свойство, которое хранит в себе ссылку на капчу (ее заполнение необязательно)
2. В AuthorizationFormHtmlParser добавлен приватный метод, который получает из текущего HTML документа ссылку на капчу
3. Из ImplicitFlowCaptchaLoginForm в CaptchaSolver теперь передается актуальная ссылка на капчу
4. Поправлен AuthorizationFormHtmlParserTests.CaptchaForm() в соответствии с изменениями  

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.
