### PR TITLE
Исправлен баг с крашем при использовании NewsFeed.Search() #1049

### DIFF
--- a/VkNet.Tests/Categories/NewsFeed/SearchTests.cs
+++ b/VkNet.Tests/Categories/NewsFeed/SearchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System.Linq;
 using VkNet.Model.RequestParams;
 using VkNet.Tests.Infrastructure;
 
@@ -36,6 +37,28 @@ namespace VkNet.Tests.Categories.NewsFeed
 
 			Assert.NotNull(result);
 			Assert.IsNotEmpty(result.NextFrom);
+		}
+
+		[Test]
+		public void Search_PostSourceData_Parsing()
+		{
+			Url = "https://api.vk.com/method/newsfeed.search";
+			ReadCategoryJsonPath(nameof(Search_PostSourceData_Parsing));
+
+			var result = Api.NewsFeed.Search(new NewsFeedSearchParams()
+			{
+				Query = "word",
+				Extended = false,
+				Count = 20
+			});
+
+			Assert.NotNull(result);
+
+			var first = result.Items.First();
+			Assert.NotNull(first.PostSource.Data);
+
+			var second = result.Items.Last();
+			Assert.IsNull(second.PostSource.Data);
 		}
 	}
 }

--- a/VkNet.Tests/TestData/Categories/NewsFeed/Search_PostSourceData_Parsing.json
+++ b/VkNet.Tests/TestData/Categories/NewsFeed/Search_PostSourceData_Parsing.json
@@ -1,0 +1,527 @@
+{
+  "response": {
+    "items": [
+      {
+        "id": 11454,
+        "date": 1564779900,
+        "owner_id": 388444282,
+        "from_id": 388444282,
+        "post_type": "post",
+        "text": "&#10071;Принимаю заказы до 23.00 завтрашнего дня&",
+        "attachments": [
+          {
+            "type": "photo",
+            "photo": {
+              "id": 457923481,
+              "album_id": -7,
+              "owner_id": 388444282,
+              "sizes": [
+                {
+                  "type": "m",
+                  "url": "https://pp.userap0e6/QCxq7rQoTDI.jpg",
+                  "width": 123,
+                  "height": 130
+                },
+                {
+                  "type": "o",
+                  "url": "https://sun9-12.u0ea/P5sQmUMx7hI.jpg",
+                  "width": 130,
+                  "height": 137
+                },
+                {
+                  "type": "p",
+                  "url": "https://pp.userap0eb/aqM7GbtC8EY.jpg",
+                  "width": 200,
+                  "height": 211
+                },
+                {
+                  "type": "q",
+                  "url": "https://pp.userap0ec/5VYdn3APezk.jpg",
+                  "width": 320,
+                  "height": 338
+                },
+                {
+                  "type": "r",
+                  "url": "https://pp.userap0ed/3WY7w0wzmxE.jpg",
+                  "width": 510,
+                  "height": 539
+                },
+                {
+                  "type": "s",
+                  "url": "https://pp.userap0e5/7yVK0XL46tQ.jpg",
+                  "width": 71,
+                  "height": 75
+                },
+                {
+                  "type": "x",
+                  "url": "https://pp.userap0e7/V2M-VvHZ1pw.jpg",
+                  "width": 572,
+                  "height": 604
+                },
+                {
+                  "type": "y",
+                  "url": "https://pp.userap0e8/4UMZxIOMxMg.jpg",
+                  "width": 764,
+                  "height": 807
+                },
+                {
+                  "type": "z",
+                  "url": "https://pp.userap0e9/dsOJZkkFR8g.jpg",
+                  "width": 909,
+                  "height": 960
+                }
+              ],
+              "text": "",
+              "date": 1564750298,
+              "access_key": "0e489d4922b25cea5c"
+            }
+          },
+          {
+            "type": "photo",
+            "photo": {
+              "id": 457923484,
+              "album_id": -7,
+              "owner_id": 388444282,
+              "sizes": [
+                {
+                  "type": "m",
+                  "url": "https://pp.userapffb/579r9yrxuWo.jpg",
+                  "width": 118,
+                  "height": 130
+                },
+                {
+                  "type": "o",
+                  "url": "https://pp.userapfff/ha98LhobElY.jpg",
+                  "width": 130,
+                  "height": 144
+                },
+                {
+                  "type": "p",
+                  "url": "https://pp.userap000/2Xt1zu09Q38.jpg",
+                  "width": 200,
+                  "height": 221
+                },
+                {
+                  "type": "q",
+                  "url": "https://pp.userap001/c28jsuskZDI.jpg",
+                  "width": 320,
+                  "height": 354
+                },
+                {
+                  "type": "r",
+                  "url": "https://pp.userap002/uBsWpPOaUck.jpg",
+                  "width": 510,
+                  "height": 564
+                },
+                {
+                  "type": "s",
+                  "url": "https://pp.userapffa/WzbgKUU4AMM.jpg",
+                  "width": 68,
+                  "height": 75
+                },
+                {
+                  "type": "x",
+                  "url": "https://pp.userapffc/IsfiT8re68I.jpg",
+                  "width": 546,
+                  "height": 604
+                },
+                {
+                  "type": "y",
+                  "url": "https://pp.userapffd/5N6-7wPw08w.jpg",
+                  "width": 730,
+                  "height": 807
+                },
+                {
+                  "type": "z",
+                  "url": "https://pp.userapffe/qdXN42eqfmI.jpg",
+                  "width": 868,
+                  "height": 960
+                }
+              ],
+              "text": "",
+              "date": 1564750299,
+              "access_key": "792afa3b7335ca7991"
+            }
+          },
+          {
+            "type": "photo",
+            "photo": {
+              "id": 457923482,
+              "album_id": -7,
+              "owner_id": 388444282,
+              "sizes": [
+                {
+                  "type": "m",
+                  "url": "https://pp.userap7ef/8B5zP24xbc8.jpg",
+                  "width": 117,
+                  "height": 130
+                },
+                {
+                  "type": "o",
+                  "url": "https://sun9-24.u7f3/eNsKrVfNvyk.jpg",
+                  "width": 130,
+                  "height": 144
+                },
+                {
+                  "type": "p",
+                  "url": "https://pp.userap7f4/FD4-YJwNiRo.jpg",
+                  "width": 200,
+                  "height": 222
+                },
+                {
+                  "type": "q",
+                  "url": "https://pp.userap7f5/A6jcoAqCYqc.jpg",
+                  "width": 320,
+                  "height": 355
+                },
+                {
+                  "type": "r",
+                  "url": "https://pp.userap7f6/iFi_nfC-XKA.jpg",
+                  "width": 510,
+                  "height": 566
+                },
+                {
+                  "type": "s",
+                  "url": "https://pp.userap7ee/JPqG-AmRFJw.jpg",
+                  "width": 67,
+                  "height": 75
+                },
+                {
+                  "type": "x",
+                  "url": "https://pp.userap7f0/or697hN3OSY.jpg",
+                  "width": 544,
+                  "height": 604
+                },
+                {
+                  "type": "y",
+                  "url": "https://pp.userap7f1/jX0r_4tHUqI.jpg",
+                  "width": 727,
+                  "height": 807
+                },
+                {
+                  "type": "z",
+                  "url": "https://pp.userap7f2/5Be3YznLSks.jpg",
+                  "width": 865,
+                  "height": 960
+                }
+              ],
+              "text": "",
+              "date": 1564750298,
+              "access_key": "1c420a4a084dc4c513"
+            }
+          },
+          {
+            "type": "photo",
+            "photo": {
+              "id": 457923483,
+              "album_id": -7,
+              "owner_id": 388444282,
+              "sizes": [
+                {
+                  "type": "m",
+                  "url": "https://pp.userapd2a/vn39K571S3E.jpg",
+                  "width": 118,
+                  "height": 130
+                },
+                {
+                  "type": "o",
+                  "url": "https://pp.userapd2e/a2fCU68k-Vg.jpg",
+                  "width": 130,
+                  "height": 144
+                },
+                {
+                  "type": "p",
+                  "url": "https://pp.userapd2f/piEEOXjRWD8.jpg",
+                  "width": 200,
+                  "height": 221
+                },
+                {
+                  "type": "q",
+                  "url": "https://pp.userapd30/pMAiue34xw8.jpg",
+                  "width": 320,
+                  "height": 354
+                },
+                {
+                  "type": "r",
+                  "url": "https://pp.userapd31/-YsUxiwgYSM.jpg",
+                  "width": 510,
+                  "height": 563
+                },
+                {
+                  "type": "s",
+                  "url": "https://pp.userapd29/MQJRDQrDBWo.jpg",
+                  "width": 68,
+                  "height": 75
+                },
+                {
+                  "type": "x",
+                  "url": "https://pp.userapd2b/XkXzL50c6f0.jpg",
+                  "width": 547,
+                  "height": 604
+                },
+                {
+                  "type": "y",
+                  "url": "https://pp.userapd2c/yXti2t98YTM.jpg",
+                  "width": 731,
+                  "height": 807
+                },
+                {
+                  "type": "z",
+                  "url": "https://pp.userapd2d/iS5ZbZzjSUg.jpg",
+                  "width": 869,
+                  "height": 960
+                }
+              ],
+              "text": "",
+              "date": 1564750299,
+              "access_key": "6a177eda7b5a80ffde"
+            }
+          },
+          {
+            "type": "photo",
+            "photo": {
+              "id": 457923480,
+              "album_id": -7,
+              "owner_id": 388444282,
+              "sizes": [
+                {
+                  "type": "m",
+                  "url": "https://pp.userap985/OvOYTe1YpmE.jpg",
+                  "width": 119,
+                  "height": 130
+                },
+                {
+                  "type": "o",
+                  "url": "https://pp.userap989/GQgYZoSqP2I.jpg",
+                  "width": 130,
+                  "height": 141
+                },
+                {
+                  "type": "p",
+                  "url": "https://pp.userap98a/BCBSKW3gt2M.jpg",
+                  "width": 200,
+                  "height": 218
+                },
+                {
+                  "type": "q",
+                  "url": "https://pp.userap98b/l6cXnTdtCu8.jpg",
+                  "width": 320,
+                  "height": 348
+                },
+                {
+                  "type": "r",
+                  "url": "https://pp.userap98c/n8Dw4ZzrHcM.jpg",
+                  "width": 510,
+                  "height": 554
+                },
+                {
+                  "type": "s",
+                  "url": "https://pp.userap984/Sn-7YeUa1l0.jpg",
+                  "width": 69,
+                  "height": 75
+                },
+                {
+                  "type": "x",
+                  "url": "https://pp.userap986/rdfP7cfTeCA.jpg",
+                  "width": 555,
+                  "height": 604
+                },
+                {
+                  "type": "y",
+                  "url": "https://pp.userap987/Dq-a4U1U0f0.jpg",
+                  "width": 742,
+                  "height": 807
+                },
+                {
+                  "type": "z",
+                  "url": "https://pp.userap988/ab4NtPLJrQM.jpg",
+                  "width": 883,
+                  "height": 960
+                }
+              ],
+              "text": "",
+              "date": 1564750298,
+              "access_key": "5ffe3bc195ca0d6129"
+            }
+          }
+        ],
+        "post_source": {
+          "type": "widget",
+          "platform": "android",
+          "data": "poll"
+        },
+        "comments": {
+          "count": 0,
+          "can_post": 0,
+          "groups_can_post": true
+        },
+        "likes": {
+          "count": 0,
+          "user_likes": 0,
+          "can_like": 1,
+          "can_publish": 1
+        },
+        "reposts": {
+          "count": 0,
+          "user_reposted": 0
+        },
+        "is_favorite": false
+      },
+      {
+        "id": 49163,
+        "date": 1564779600,
+        "owner_id": -31130529,
+        "from_id": -31130529,
+        "post_type": "post",
+        "text": "Автор: #ano_hito      Аниме/Игра: #оригинальное_изображение",
+        "marked_as_ads": 0,
+        "attachments": [
+          {
+            "type": "photo",
+            "photo": {
+              "id": 457261435,
+              "album_id": -7,
+              "owner_id": -31130529,
+              "user_id": 100,
+              "sizes": [
+                {
+                  "type": "m",
+                  "url": "https://pp.userap51b/gf7llYmK6Zk.jpg",
+                  "width": 130,
+                  "height": 87
+                },
+                {
+                  "type": "o",
+                  "url": "https://pp.userap520/vYO1h5C_C8M.jpg",
+                  "width": 130,
+                  "height": 87
+                },
+                {
+                  "type": "p",
+                  "url": "https://pp.userap521/6fwbpEtKaTM.jpg",
+                  "width": 200,
+                  "height": 133
+                },
+                {
+                  "type": "q",
+                  "url": "https://pp.userap522/EvseLN_rZR8.jpg",
+                  "width": 320,
+                  "height": 213
+                },
+                {
+                  "type": "r",
+                  "url": "https://pp.userap523/M7IBHq2GsZ0.jpg",
+                  "width": 510,
+                  "height": 340
+                },
+                {
+                  "type": "s",
+                  "url": "https://pp.userap51a/E1C9EXRl-_A.jpg",
+                  "width": 75,
+                  "height": 50
+                },
+                {
+                  "type": "w",
+                  "url": "https://pp.userap51f/aLIYycCg6pA.jpg",
+                  "width": 1920,
+                  "height": 1280
+                },
+                {
+                  "type": "x",
+                  "url": "https://pp.userap51c/hIZMBLWXOO0.jpg",
+                  "width": 604,
+                  "height": 403
+                },
+                {
+                  "type": "y",
+                  "url": "https://pp.userap51d/4kkElKwMa2g.jpg",
+                  "width": 807,
+                  "height": 538
+                },
+                {
+                  "type": "z",
+                  "url": "https://pp.userap51e/4nAA-sz32v0.jpg",
+                  "width": 1280,
+                  "height": 853
+                }
+              ],
+              "text": "Скачать (1920x1280): https://vk.com/doc137137438_510307295?hash=4f283e33f0e8ee1704&dl=GEZTOMJTG42DGOA:1563735010:9ed09e4d3520ac8465&api=1&no_preview=1",
+              "date": 1563735014,
+              "post_id": 48902,
+              "access_key": "8d07e4d17d961a9511"
+            }
+          }
+        ],
+        "post_source": {
+          "type": "api"
+        },
+        "comments": {
+          "count": 0,
+          "can_post": 1,
+          "groups_can_post": true
+        },
+        "likes": {
+          "count": 0,
+          "user_likes": 0,
+          "can_like": 1,
+          "can_publish": 1
+        },
+        "reposts": {
+          "count": 0,
+          "user_reposted": 0
+        },
+        "views": {
+          "count": 2
+        },
+        "is_favorite": false
+      }
+    ],
+    "count": 1000,
+    "total_count": 150428,
+    "profiles": [
+      {
+        "id": 388444282,
+        "first_name": "Элина",
+        "last_name": "Стайл",
+        "is_closed": false,
+        "can_access_closed": true,
+        "sex": 1,
+        "screen_name": "elinastayl",
+        "photo_50": "https://sun7-8.usvGTLRIpkI.jpg?ava=1",
+        "photo_100": "https://sun7-8.usJHYEQMRT8.jpg?ava=1",
+        "online": 1,
+        "online_app": 2274003,
+        "online_mobile": 1
+      }
+    ],
+    "groups": [
+      {
+        "id": 31130529,
+        "name": "Аниме картинки и не только",
+        "screen_name": "waldub",
+        "is_closed": 0,
+        "type": "group",
+        "is_admin": 0,
+        "is_member": 0,
+        "is_advertiser": 0,
+        "photo_50": "https://sun9-24.u99KwgrOJg.jpg?ava=1",
+        "photo_100": "https://pp.userapYKMFpckk4.jpg?ava=1",
+        "photo_200": "https://pp.userapvfWx-jTeU.jpg?ava=1"
+      },
+      {
+        "id": 184898883,
+        "name": "Заявки и лиды на продвижение сайта",
+        "screen_name": "leads_seo",
+        "is_closed": 0,
+        "type": "group",
+        "is_admin": 0,
+        "is_member": 0,
+        "is_advertiser": 0,
+        "photo_50": "https://pp.userapR8bUB8-RY.jpg?ava=1",
+        "photo_100": "https://pp.userapYoprSoEpg.jpg?ava=1",
+        "photo_200": "https://pp.userap2OASVeX04.jpg?ava=1"
+      }
+    ],
+    "next_from": "3/-184898883_177"
+  }
+}

--- a/VkNet/Model/Attachments/Link.cs
+++ b/VkNet/Model/Attachments/Link.cs
@@ -16,6 +16,11 @@ namespace VkNet.Model.Attachments
 		protected override string Alias => "link";
 
 		/// <summary>
+		/// Идентификатор ссылки
+		/// </summary>
+		public string LinkId { get; set; }
+
+		/// <summary>
 		/// Адрес ссылки.
 		/// </summary>
 		public Uri Uri { get; set; }
@@ -102,9 +107,18 @@ namespace VkNet.Model.Attachments
 		/// <returns> </returns>
 		public static Link FromJson(VkResponse response)
 		{
+			var id = default(long?);
+			var linkId = (string)response["id"];
+
+			if (long.TryParse(linkId, out long temporaryId))
+			{
+				id = temporaryId;
+			}
+
 			return new Link
 			{
-				Id = response["id"],
+				Id = id,
+				LinkId = linkId,
 				Uri = response["url"],
 				Title = response["title"],
 				Description = response["description"] ?? response["desc"],

--- a/VkNet/Model/PostSource.cs
+++ b/VkNet/Model/PostSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using VkNet.Enums.SafetyEnums;
 using VkNet.Utils;
@@ -37,6 +37,7 @@ namespace VkNet.Model
 		/// значения поля type:
 		/// </summary>
 		[JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
+		[JsonConverter(typeof(SafetyEnumJsonConverter))]
 		public PostSourceData Data { get; set; }
 
 		/// <summary>

--- a/VkNet/Model/PostSourceData.cs
+++ b/VkNet/Model/PostSourceData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using VkNet.Enums.SafetyEnums;
 using VkNet.Utils;
 
 namespace VkNet.Model
@@ -8,48 +9,31 @@ namespace VkNet.Model
 	/// поля type:
 	/// </summary>
 	[Serializable]
-	public class PostSourceData
+	public class PostSourceData : SafetyEnum<PostSourceData>
 	{
 		/// <summary>
 		/// Изменение статуса под именем пользователя.
 		/// </summary>
-		public string ProfileActivity { get; set; }
+		public static readonly PostSourceData ProfileActivity = RegisterPossibleValue(value: "profile_activity");
 
 		/// <summary>
 		/// Изменение профильной фотографии пользователя.
 		/// </summary>
-		public string ProfilePhoto { get; set; }
+		public static readonly PostSourceData ProfilePhoto = RegisterPossibleValue(value: "profile_photo");
 
 		/// <summary>
 		/// Виджет комментариев.
 		/// </summary>
-		public string Comments { get; set; }
+		public static readonly PostSourceData Comments = RegisterPossibleValue(value: "comments");
 
 		/// <summary>
 		/// Виджет «Мне нравится».
 		/// </summary>
-		public string Like { get; set; }
+		public static readonly PostSourceData Like = RegisterPossibleValue(value: "like");
 
 		/// <summary>
 		/// Виджет опросов.
 		/// </summary>
-		public string Poll { get; set; }
-
-		/// <summary>
-		/// Разобрать из json.
-		/// </summary>
-		/// <param name="response"> Ответ сервера. </param>
-		/// <returns> </returns>
-		public static PostSourceData FromJson(VkResponse response)
-		{
-			return new PostSourceData
-			{
-					ProfileActivity = response[key: "profile_activity"]
-					, ProfilePhoto = response[key: "profile_photo"]
-					, Comments = response[key: "comments"]
-					, Like = response[key: "like"]
-					, Poll = response[key: "poll"]
-			};
-		}
+		public static readonly PostSourceData Poll = RegisterPossibleValue(value: "poll");
 	}
 }


### PR DESCRIPTION
## Список изменений:
1. Исправлен баг с получением объекта PostSourceData, который приводил к крашу
2. Исправлен баг с получением объекта Link (ссылка), который приводил к крашу. Разработчики VK API решили, что в некоторых случаях сервер будет присылать идентификатор Link'a не в виде целого длинного числа, а больше похожий на Guid. Чтобы не потерять обратную совместимость с предыдущими версиями библиотеки, было принято решение записывать идентификатор, содержащий буквы, в отдельное, новое свойство под названием LinkId. Во всех остальных случаях будут заполняться и Id, и LinkId
3. Написаны тесты под обновленную функциональность

##### Выполнены следующие пункты:
- [x] Проверено, что код не содержит конфликтов
- [x] Написаны новые тесты. Проверено, что другие тесты не падают