### PR TITLE
Исправлен баг в методе ImplicitFlowVkAuthorization.GetPageType(Uri uri) #1169

### DIFF
--- a/VkNet.Tests/Infrastructure/BaseTest.cs
+++ b/VkNet.Tests/Infrastructure/BaseTest.cs
@@ -118,14 +118,10 @@ namespace VkNet.Tests
 			Api.CaptchaSolver = Mocker.Get<ICaptchaSolver>();
 			SetupCaptchaHandler();
 
-			Api.Authorize(new ApiAuthParams
-			{
-				ApplicationId = 1,
-				Login = "login",
-				Password = "pass",
-				Settings = Settings.All,
-				Phone = "89510000000"
-			});
+			Api.Authorize
+			(
+				Mocker.Get<IApiAuthParams>()
+			);
 
 			Api.RequestsPerSecond = int.MaxValue;
 		}

--- a/VkNet.Tests/Infrastructure/ImplicitFlowVkAuthorizationTests.cs
+++ b/VkNet.Tests/Infrastructure/ImplicitFlowVkAuthorizationTests.cs
@@ -120,9 +120,11 @@ namespace VkNet.Tests.Infrastructure
 		}
 
 		[Test]
-		public void GetPageType_TwoFactor()
+		[TestCase("https://m.vk.com/login?act=authcheck&api_hash=api_hash")]
+		[TestCase("https://m.vk.com:443/login?act=authcheck&api_hash=api_hash")]
+		public void GetPageType_TwoFactor(string uriString)
 		{
-			var url = new Uri("https://m.vk.com/login?act=authcheck&api_hash=api_hash");
+			var url = new Uri(uriString);
 
 			var auth = new ImplicitFlowVkAuthorization();
 			var result = auth.GetPageType(url);
@@ -131,9 +133,11 @@ namespace VkNet.Tests.Infrastructure
 		}
 
 		[Test]
-		public void GetPageType_TwoFactor_AfterIncorrectEnter()
+		[TestCase("https://m.vk.com/login?act=authcheck&m=442")]
+		[TestCase("https://m.vk.com:443/login?act=authcheck&m=442")]
+		public void GetPageType_TwoFactor_AfterIncorrectEnter(string uriString)
 		{
-			var url = new Uri("https://m.vk.com/login?act=authcheck&m=442");
+			var url = new Uri(uriString);
 
 			var auth = new ImplicitFlowVkAuthorization();
 			var result = auth.GetPageType(url);

--- a/VkNet/Infrastructure/Authorization/ImplicitFlow/ImplicitFlowVkAuthorization.cs
+++ b/VkNet/Infrastructure/Authorization/ImplicitFlow/ImplicitFlowVkAuthorization.cs
@@ -79,7 +79,7 @@ namespace VkNet.Infrastructure.Authorization.ImplicitFlow
 				return ImplicitFlowPageType.Error;
 			}
 
-			if (original.StartsWith("https://m.vk.com/login?act=authcheck"))
+			if (original.Contains("/login?act=authcheck"))
 			{
 				return ImplicitFlowPageType.TwoFactor;
 			}


### PR DESCRIPTION
## Список изменений:
1. Исправлен баг в методе ImplicitFlowVkAuthorization.GetPageType(Uri uri), который вызывал исключение, если в корректном URL указан порт по которому нужно выполнить запрос. Например, m.vk.com:443/login.php?...;
2. Теперь в BaseTest ApiAuthParams возвращаются из AutoMocker'a и передаются в Api.Authorize (если коротко: убрал повторяемость кода из этого метода).

##### Выполнены следующие пункты:
- [x] Проверено, что код не содержит конфликтов
- [x] Проверено, что не падают существующие тесты