### PR TITLE
Исправлен тип данных у свойства OwnerId - id сообщества

### DIFF
--- a/VkNet/Model/EventData.cs
+++ b/VkNet/Model/EventData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using VkNet.Enums.SafetyEnums;
 using VkNet.Utils;
@@ -50,7 +50,7 @@ namespace VkNet.Model
 		/// Для <see cref="Type"/> со значением <see cref="MessageEventType.OpenApp"/>.
 		/// </remarks>
 		[JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
-		public ulong? OwnerId { get; set; }
+		public long? OwnerId { get; set; }
 
 		/// <summary>
 		/// Разобрать из json.

--- a/VkNet/Model/Keyboard/MessageKeyboardButtonAction.cs
+++ b/VkNet/Model/Keyboard/MessageKeyboardButtonAction.cs
@@ -87,7 +87,7 @@ namespace VkNet.Model.Keyboard
 		/// Для <see cref="Type"/> со значением <see cref="KeyboardButtonActionType.VkApp"/>
 		/// </remarks>
 		[JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
-		public ulong? OwnerId { get; set; }
+		public long? OwnerId { get; set; }
 
 		/// <summary>
 		/// user_id: 1-2e9


### PR DESCRIPTION
## Список изменений
- в MessageKeyboardButtonAction изменён тип данных с ulong? на long? свойства OwnerId - идентификатора сообщества.
- в EventData изменён тип данных с ulong? на long? свойства OwnerId. 

Идентификатор сообщества является отрицательным числом. 
Для кнопки с типом VkApp при использовании метода Messages.GetConversations Вк присылает именно отрицательный owner_id в объекте last_message, из-за чего возникает ошибка конвертации отрицательного значения в UInt64?
