### PR TITLE
Fix incorrect check for limit in MessagesGetLongPoolHistoryParams

### DIFF
--- a/VkNet/Model/RequestParams/Messages/MessagesGetLongPollHistoryParams.cs
+++ b/VkNet/Model/RequestParams/Messages/MessagesGetLongPollHistoryParams.cs
@@ -65,7 +65,7 @@ namespace VkNet.Model.RequestParams
 		public long? EventsLimit
 		{
 			get => _eventsLimit;
-			set => _eventsLimit = (!value.HasValue || value >= EVENTS_LIMIT_MIN) ? value : EVENTS_LIMIT_MIN;
+			set => _eventsLimit = (!value.HasValue || value <= EVENTS_LIMIT_MIN) ? value : EVENTS_LIMIT_MIN;
 		}
 
 		/// <summary>

--- a/VkNet/Model/RequestParams/Messages/MessagesSendParams.cs
+++ b/VkNet/Model/RequestParams/Messages/MessagesSendParams.cs
@@ -23,7 +23,7 @@ namespace VkNet.Model.RequestParams
 		[JsonProperty("domain")]
 		public string Domain { get; set; }
 
-		// <summary>
+		/// <summary>
 		/// Заголовок сообщения(выделется жирным)
 		/// </summary>
 		[JsonProperty("title")]


### PR DESCRIPTION
## Список изменений
- Исправлена проверка на лимит в `MessagesGetLongPoolHistoryParams`. 
- Поведение до - проверка срабатывает если значения `null`, или оно больше чем лимит. Таким образом можно установить лимит больше, чем ограничение, если передать любое число больше чем `EVENTS_LIMIT_MIN`
- Правильное поведение - установка значения, если передано `null` или если значение меньше чем лимит, в противном случае, устанавливается дефолтное. 

##### Обязательно выполните следующие пункты:
- [+] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [+] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
[Edit.] Тест фэйлит не по моей вине)

