### PR TITLE
Исправление поведения MessagesCategory.SetActivity

### DIFF
--- a/VkNet.Tests/Categories/Messages/MessagesCategoryTest.cs
+++ b/VkNet.Tests/Categories/Messages/MessagesCategoryTest.cs
@@ -666,17 +666,5 @@ namespace VkNet.Tests.Categories.Messages
 			Assert.That(response.Chats[0].Users.ElementAt(1), Is.EqualTo(6492));
 			Assert.That(response.Chats[0].Users.ElementAt(2), Is.EqualTo(1708231));
 		}
-
-		[Test]
-		public void SetActivity_NormalCase_True()
-		{
-			Url = "https://api.vk.com/method/messages.setActivity";
-
-			ReadJsonFile(JsonPaths.True);
-
-			var result = Api.Messages.SetActivity("7550525", MessageActivityType.Typing);
-
-			Assert.That(result, Is.True);
-		}
 	}
 }

--- a/VkNet.Tests/Categories/Messages/MessagesSetActivityTests.cs
+++ b/VkNet.Tests/Categories/Messages/MessagesSetActivityTests.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+using VkNet.Enums.SafetyEnums;
+using VkNet.Exception;
+using VkNet.Tests.Infrastructure;
+
+namespace VkNet.Tests.Categories.Messages
+{
+	[TestFixture]
+	public class MessagesSetActivityTests : MessagesBaseTests
+	{
+		[Test]
+		public void Messages_SetActivity_Without_PeerId_And_GroupId_Throws()
+		{
+			Assert.Throws<VkApiException>(() => Api.Messages.SetActivity("some_user_id", MessageActivityType.Typing));
+		}
+
+		[Test]
+		public void Messages_SetActivity_With_Both_PeerId_And_GroupId_Throws()
+		{
+			Assert.Throws<VkApiException>(() => Api.Messages.SetActivity("some_user_id", MessageActivityType.Typing, 125, 125));
+		}
+
+		[Test]
+		public void Messages_SetActivity_With_PeerId_DoesntFail()
+		{
+			Url = "https://api.vk.com/method/messages.setActivity";
+
+			ReadJsonFile(JsonPaths.True);
+
+			var result = Api.Messages.SetActivity("7550525", MessageActivityType.Typing, 1);
+
+			Assert.That(result, Is.True);
+		}
+
+		[Test]
+		public void Messages_SetActivity_With_GroupId_DoesntFail()
+		{
+			Url = "https://api.vk.com/method/messages.setActivity";
+
+			ReadJsonFile(JsonPaths.True);
+
+			var result = Api.Messages.SetActivity("7550525", MessageActivityType.Typing, null, 2);
+
+			Assert.That(result, Is.True);
+		}
+	}
+}

--- a/VkNet/Categories/MessagesCategory.cs
+++ b/VkNet/Categories/MessagesCategory.cs
@@ -473,7 +473,7 @@ namespace VkNet.Categories
 
 			if (peerId is not null && groupId is not null)
 			{
-				throw new VkApiException("This method doesn't accept 'peerId' and 'groupId' specified simultaneously");
+				throw new VkApiException("This method doesn't accept 'peerId' and 'groupId' being specified simultaneously");
 			}
 
 			var parameters = new VkParameters

--- a/VkNet/Categories/MessagesCategory.cs
+++ b/VkNet/Categories/MessagesCategory.cs
@@ -397,12 +397,12 @@ namespace VkNet.Categories
 			{
 				throw new ArgumentException("Parameter Ids has no elements.", nameof(messageIds));
 			}
-			
+
 
 			var parameters = new VkParameters
 			{
-				{ "message_ids", messageIds!=null?messageIds.ToList():null },
-				{ "conversation_message_ids", conversationMessageIds!=null?conversationMessageIds.ToList():null },
+				{ "message_ids", messageIds?.ToList() },
+				{ "conversation_message_ids", conversationMessageIds?.ToList() },
 				{ "peer_id", PeerId },
 				{ "spam", spam },
 				{ "group_id", groupId },
@@ -425,18 +425,18 @@ namespace VkNet.Categories
 		public IDictionary<ulong, bool> Delete(IEnumerable<ulong> messageIds, bool? spam = null, ulong? groupId = null,
 												bool? deleteForAll = null)
 		{
-			return Delete(messageIds,null,null,spam,groupId, deleteForAll );
+			return Delete(messageIds, null, null, spam, groupId, deleteForAll);
 		}
 
 		/// <inheritdoc />
-		public IDictionary<ulong, bool> Delete(IEnumerable<ulong> conversationMessageIds, ulong PeerId, 
+		public IDictionary<ulong, bool> Delete(IEnumerable<ulong> conversationMessageIds, ulong PeerId,
 												bool? spam = null, ulong? groupId = null,
 												bool? deleteForAll = null)
 		{
 
-			return Delete(null,conversationMessageIds,PeerId,spam,groupId);
+			return Delete(null, conversationMessageIds, PeerId, spam, groupId);
 		}
-		
+
 		/// <inheritdoc />
 		public bool Restore(ulong messageId, ulong? groupId = null)
 		{
@@ -466,6 +466,16 @@ namespace VkNet.Categories
 		/// <inheritdoc />
 		public bool SetActivity(string userId, MessageActivityType type, long? peerId = null, ulong? groupId = null)
 		{
+			if (peerId is null && groupId is null)
+			{
+				throw new VkApiException("Either one of the parameters 'peerId' and 'groupId' must be specified.");
+			}
+
+			if (peerId is not null && groupId is not null)
+			{
+				throw new VkApiException("This method doesn't accept 'peerId' and 'groupId' specified simultaneously");
+			}
+
 			var parameters = new VkParameters
 			{
 				{ "used_id", userId },


### PR DESCRIPTION

## Список изменений
- Исправлено поведение MessagesCategory.SetActivity.
Данный метод устанавливает активность пользователя в диалоге, поэтому ему необходим хотя бы 1 из параметров, указывающих на диалог (peerId или groupId)
- Добавлены тесты для указанного метода
- Fixes #1022 

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
