### PR TITLE
Ограничения методов Ads.CreateCampaign и Ads.CreateClients

### DIFF
--- a/VkNet/Categories/AdsCategory.cs
+++ b/VkNet/Categories/AdsCategory.cs
@@ -65,6 +65,11 @@ namespace VkNet.Categories
 		/// <inheritdoc/>
 		public ReadOnlyCollection<CreateCampaignResult> CreateCampaigns(AdsDataSpecificationParams<CampaignSpecification> campaignsDataSpecification)
 		{
+			if (campaignsDataSpecification.Data.Length > 50)
+			{
+				throw new ArgumentOutOfRangeException(nameof(campaignsDataSpecification), "This method doesn't support more than 50 campaigns per call");
+			}
+
 			return _vk.Call<ReadOnlyCollection<CreateCampaignResult>>("ads.createCampaigns",
 				new VkParameters
 				{
@@ -76,6 +81,11 @@ namespace VkNet.Categories
 		/// <inheritdoc/>
 		public ReadOnlyCollection<CreateClientResult> CreateClients(AdsDataSpecificationParams<ClientSpecification> clientDataSpecification)
 		{
+			if (clientDataSpecification.Data.Length > 50)
+			{
+				throw new ArgumentOutOfRangeException(nameof(clientDataSpecification), "This method doesn't support more than 50 clients per call");
+			}
+
 			return _vk.Call<ReadOnlyCollection<CreateClientResult>>("ads.createClients",
 				new VkParameters
 				{

--- a/VkNet/Model/Results/Ads/CreateCampaignResult.cs
+++ b/VkNet/Model/Results/Ads/CreateCampaignResult.cs
@@ -14,7 +14,7 @@ namespace VkNet.Model
 		/// Идентификатор созданного объявления.
 		/// </summary>
 		[JsonProperty("id")]
-		public long Id { get; set; }
+		public long? Id { get; set; }
 
 		/// <summary>
 		/// Массив объектов UserSpecification

--- a/VkNet/Model/Results/Ads/CreateClientResult.cs
+++ b/VkNet/Model/Results/Ads/CreateClientResult.cs
@@ -14,7 +14,7 @@ namespace VkNet.Model
 		/// Идентификатор созданного объявления.
 		/// </summary>
 		[JsonProperty("id")]
-		public long Id { get; set; }
+		public long? Id { get; set; }
 
 		/// <summary>
 		/// Массив объектов UserSpecification


### PR DESCRIPTION
## Список изменений
- Добавлено ограничение на 50 элементов в запросах Ads.CreateCampaign и Ads.CreateClients
В соответствии с документацией методов [ads.createCampaigns](https://vk.com/dev/ads.createCampaigns) и [ads.createCampaigns](https://vk.com/dev/ads.createCampaigns) эти методы допускают максимум 50 элементов на запрос. 
- Добавлен `?` к полям Id результатов выполнения этих методов, т.к. в документации сказано, что там может вернуться `null` в случае ошибки.

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
