### PR TITLE
Исправление NotificationsCategory.Get вызывающего ошибку десериализации

### DIFF
--- a/VkNet/Abstractions/Category/Async/INotificationsCategoryAsync.cs
+++ b/VkNet/Abstractions/Category/Async/INotificationsCategoryAsync.cs
@@ -253,8 +253,8 @@ namespace VkNet.Abstractions
 		/// <remarks>
 		/// Страница документации ВКонтакте http://vk.com/dev/notifications.get
 		/// </remarks>
-		Task<IEnumerable<NotificationGetResult>> GetAsync(ulong? count = null, string startFrom = null, IEnumerable<string> filters = null,
-														long? startTime = null, long? endTime = null, CancellationToken token = default);
+		Task<NotificationGetResult> GetAsync(ulong? count = null, string startFrom = null, IEnumerable<string> filters = null,
+											long? startTime = null, long? endTime = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Сбрасывает счетчик непросмотренных оповещений об ответах других пользователей

--- a/VkNet/Abstractions/Category/INotificationsCategory.cs
+++ b/VkNet/Abstractions/Category/INotificationsCategory.cs
@@ -9,8 +9,8 @@ namespace VkNet.Abstractions
 	public interface INotificationsCategory : INotificationsCategoryAsync
 	{
 		/// <inheritdoc cref="INotificationsCategoryAsync.GetAsync"/>
-		IEnumerable<NotificationGetResult> Get(ulong? count = null, string startFrom = null, IEnumerable<string> filters = null,
-												long? startTime = null, long? endTime = null);
+		NotificationGetResult Get(ulong? count = null, string startFrom = null, IEnumerable<string> filters = null,
+								long? startTime = null, long? endTime = null);
 
 		/// <inheritdoc cref="INotificationsCategoryAsync.MarkAsViewedAsync"/>
 		bool MarkAsViewed();

--- a/VkNet/Categories/Async/NotificationsCategoryAsync.cs
+++ b/VkNet/Categories/Async/NotificationsCategoryAsync.cs
@@ -12,9 +12,9 @@ namespace VkNet.Categories
 	public partial class NotificationsCategory
 	{
 		/// <inheritdoc />
-		public Task<IEnumerable<NotificationGetResult>> GetAsync(ulong? count = null, string startFrom = null,
-																IEnumerable<string> filters = null, long? startTime = null,
-																long? endTime = null, CancellationToken token = default)
+		public Task<NotificationGetResult> GetAsync(ulong? count = null, string startFrom = null,
+													IEnumerable<string> filters = null, long? startTime = null,
+													long? endTime = null, CancellationToken token = default)
 		{
 			return TypeHelper.TryInvokeMethodAsync(func: () => Get(count, startFrom, filters, startTime, endTime));
 		}

--- a/VkNet/Categories/NotificationsCategory.cs
+++ b/VkNet/Categories/NotificationsCategory.cs
@@ -27,13 +27,13 @@ namespace VkNet.Categories
 		}
 
 		/// <inheritdoc />
-		public IEnumerable<NotificationGetResult> Get(ulong? count = null
-													, string startFrom = null
-													, IEnumerable<string> filters = null
-													, long? startTime = null
-													, long? endTime = null)
+		public NotificationGetResult Get(ulong? count = null
+										, string startFrom = null
+										, IEnumerable<string> filters = null
+										, long? startTime = null
+										, long? endTime = null)
 		{
-			return _vk.Call<IEnumerable<NotificationGetResult>>(methodName: "notifications.get",
+			return _vk.Call<NotificationGetResult>("notifications.get",
 				parameters: new VkParameters
 				{
 					{ "count", count },


### PR DESCRIPTION
Signed-off-by: Bird Egop <sampletext32@bk.ru>

## Список изменений
- В соответствии с документацией, метод notifiications.get возвращает объект со списками, а не список объектов. 

##### Обязательно выполните следующие пункты:
- [x] Проверьте что ваш код не содержит конфликтов, и исправьте их по необходимости
- [x] Напишите тесты, и обязательно проверьте что не падают другие.

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
