### PR TITLE
Изменение MessagesCategoryAsync.cs и MessagesCategory.cs, методы DeleteAsync и Delete.

### DIFF
--- a/VkNet/Categories/Async/MessagesCategoryAsync.cs
+++ b/VkNet/Categories/Async/MessagesCategoryAsync.cs
@@ -40,11 +40,6 @@ public partial class MessagesCategory
 
 	/// <inheritdoc />
 	public Task<IDictionary<ulong, bool>> DeleteAsync(IEnumerable<ulong> messageIds, bool? spam = null, ulong? groupId = null,
-													bool? deleteForAll = null) => TypeHelper.TryInvokeMethodAsync(() =>
-		Delete(messageIds, spam, groupId, deleteForAll));
-
-	/// <inheritdoc />
-	public Task<IDictionary<ulong, bool>> DeleteAsync(IEnumerable<ulong> messageIds, bool? spam = null, ulong? groupId = null,
             bool deleteForAll = false) => TypeHelper.TryInvokeMethodAsync(
 		() => Delete(messageIds, spam, groupId, deleteForAll));
 	

--- a/VkNet/Categories/Async/MessagesCategoryAsync.cs
+++ b/VkNet/Categories/Async/MessagesCategoryAsync.cs
@@ -44,21 +44,14 @@ public partial class MessagesCategory
 		Delete(messageIds, spam, groupId, deleteForAll));
 
 	/// <inheritdoc />
-	public Task<IDictionary<ulong, bool>> DeleteAsync(IEnumerable<ulong> conversationMessageIds, ulong peerId, bool? spam = null,
-													ulong? groupId = null, bool? deleteForAll = null) => TypeHelper.TryInvokeMethodAsync(
-		() =>
-			Delete(conversationMessageIds, peerId, spam, groupId, deleteForAll));
-
+	public Task<IDictionary<ulong, bool>> DeleteAsync(IEnumerable<ulong> messageIds, bool? spam = null, ulong? groupId = null,
+            bool deleteForAll = false) => TypeHelper.TryInvokeMethodAsync(
+		() => Delete(messageIds, spam, groupId, deleteForAll));
+	
 	/// <inheritdoc />
-	public Task<IDictionary<ulong, bool>> DeleteAsync(IEnumerable<ulong> conversationMessageIds, ulong? peerId, bool? spam = null,
-													ulong? groupId = null,
-													bool? deleteForAll = null) => TypeHelper.TryInvokeMethodAsync(() =>
-		Delete(null,
-			conversationMessageIds,
-			peerId,
-			spam,
-			groupId,
-			deleteForAll));
+	public Task<IDictionary<ulong, bool>> DeleteAsync(IEnumerable<ulong> conversationMessageIds, ulong peerId, ulong? groupId = null, bool? spam = null,
+            bool deleteForAll = false) => TypeHelper.TryInvokeMethodAsync(
+		() => Delete(conversationMessageIds, peerId, groupId, spam, deleteForAll));
 
 	/// <inheritdoc />
 	public Task<Chat> DeleteChatPhotoAsync(ulong chatId, ulong? groupId = null) =>

--- a/VkNet/Categories/MessagesCategory.cs
+++ b/VkNet/Categories/MessagesCategory.cs
@@ -800,7 +800,7 @@ public partial class MessagesCategory : IMessagesCategory
             //Если вы авторизованы с ключом доступа сообщества, то вы не можете удалять сообщения администратора беседы(также, как и не будете иметь данной возможности,
             //удаляя сообщения администратора, будучи обычным пользователем в беседе)
             //(На момент вызова возникнет ошибка запроса).
-            var response = Client.vkService.Call("messages.delete", parameters);
+            var response = _vk.Call("messages.delete", parameters);
 
             var result = new Dictionary<ulong, bool>();
 

--- a/VkNet/Categories/MessagesCategory.cs
+++ b/VkNet/Categories/MessagesCategory.cs
@@ -746,69 +746,80 @@ public partial class MessagesCategory : IMessagesCategory
 	public ulong DeleteDialog(long? userId, long? peerId = null, uint? offset = null, uint? count = null) =>
 		DeleteConversation(userId, peerId, null);
 
-	private IDictionary<ulong, bool> Delete(IEnumerable<ulong> messageIds, IEnumerable<ulong> conversationMessageIds = null,
-											ulong? peerId = null, bool? spam = null, ulong? groupId = null,
-											bool? deleteForAll = null)
-	{
-		if (messageIds == null && conversationMessageIds == null)
-		{
-			throw new ArgumentNullException(nameof(conversationMessageIds),
-				"Parameter conversationMessageIds or messageIds can not be null.");
-		}
+	private IDictionary<ulong, bool> ImplementationDelete(IEnumerable<ulong>? messageIds = null,
+            IEnumerable<ulong>? conversationMessageIds = null,
+            ulong? peerId = null, bool? spam = null, ulong? groupId = null,
+            bool deleteForAll = false)
+        {
+            if (messageIds == null && conversationMessageIds == null)
+            {
+                throw new ArgumentNullException(nameof(conversationMessageIds), "Parameter conversationMessageIds or messageIds can not be null.");
+            }
 
-		var ids = messageIds != null
-			? messageIds.ToList()
-			: conversationMessageIds.ToList();
+            var ids = messageIds != null
+                ? messageIds.ToList()
+                : conversationMessageIds!.ToList();
 
-		if (ids.Count == 0)
-		{
-			throw new ArgumentException("Parameter Ids has no elements.", nameof(messageIds));
-		}
+            if (ids.Count == 0)
+            {
+                throw new ArgumentException("Parameter Ids has no elements.", nameof(ids));
+            }
 
-		var parameters = new VkParameters
-		{
-			{
-				"message_ids", messageIds?.ToList()
-			},
-			{
-				"cmids", conversationMessageIds?.ToList()
-			},
-			{
-				"peer_id", peerId
-			},
-			{
-				"spam", spam
-			},
-			{
-				"group_id", groupId
-			},
-			{
-				"delete_for_all", deleteForAll
-			}
-		};
+            var parameters = new VkParameters
+            {
+                {"delete_for_all", deleteForAll}
+            };
 
-		var response = _vk.Call("messages.delete", parameters);
+            //Наличие spam неприемлимо, в случаях, когда авторизация ApiVk произошла с ключом сообщества, а не ключом пользователя.
+            if (spam != null)
+            {
+                parameters.Add("spam", spam);
+            }
 
-		var result = new Dictionary<ulong, bool>();
+            //Наличие peerId в запросе без cmids не имеет значения и может вызвать неожиданные ошибки.
+            if (peerId != null)
+            {
+                parameters.Add("peer_id",peerId);
+            }
 
-		foreach (var id in ids)
-		{
-			bool isDeleted = response[id.ToString(CultureInfo.InvariantCulture)];
-			result.Add(id, isDeleted);
-		}
+            //Использование предполагает пройденную авторизацию с ключом пользователя для удаления со стороны сообщества,
+            //при использовании в одном наборе параметров, могут возникнут непредвиденные исключения.
+            //Если используется в личке между двумя пользователями, а также если нужно удалить с пользовательским ключом(являсь администратором беседы) -
+            //необходимость в использовании отпадает.
+            //Если авторизация пройдена со стороны сообщества, то необходимости в использовании тоже нет.
+            if (groupId != null)
+            {
+                parameters.Add("group_id", groupId);
+            }
 
-		return result;
-	}
+            //При использовании cmids нежелательно использовать ещё и message_ids в одном наборе параметров,
+            //так как возникают неуправляемые исключения со стороны ApiVk, такие как oldMessage.
+            //Хотя сообщение по id лежит менее 24 часов.
+            parameters.Add(messageIds != null ? "message_ids" : "cmids", ids);
+
+            //Если вы авторизованы с ключом доступа сообщества, то вы не можете удалять сообщения администратора беседы(также, как и не будете иметь данной возможности,
+            //удаляя сообщения администратора, будучи обычным пользователем в беседе)
+            //(На момент вызова возникнет ошибка запроса).
+            var response = Client.vkService.Call("messages.delete", parameters);
+
+            var result = new Dictionary<ulong, bool>();
+
+            foreach (var id in ids)
+            {
+                bool isDeleted = response[id.ToString(CultureInfo.InvariantCulture)];
+                result.Add(id, isDeleted);
+            }
+
+            return result;
+        }
 
 	/// <inheritdoc />
 	public IDictionary<ulong, bool> Delete(IEnumerable<ulong> messageIds, bool? spam = null, ulong? groupId = null,
-											bool? deleteForAll = null) => Delete(messageIds, null, null, spam, groupId,
-		deleteForAll);
+            bool deleteForAll = false) => ImplementationDelete(messageIds:messageIds,spam:spam,groupId:groupId,deleteForAll:deleteForAll);
 
 	/// <inheritdoc />
-	public IDictionary<ulong, bool> Delete(IEnumerable<ulong> conversationMessageIds, ulong peerId,
-											bool? spam = null, ulong? groupId = null,
-											bool? deleteForAll = null) => Delete(null, conversationMessageIds, peerId, spam, groupId);
+	public IDictionary<ulong, bool> Delete(IEnumerable<ulong> conversationMessageIds, ulong peerId, ulong? groupId = null, bool? spam = null,
+            bool deleteForAll = false) => ImplementationDelete(conversationMessageIds:conversationMessageIds,peerId:peerId, groupId:groupId, spam:spam, deleteForAll:deleteForAll);
 
 	/// <inheritdoc />
 	public bool Restore(ulong messageId, ulong? groupId = null)


### PR DESCRIPTION
## Список изменений
- 2 перегрузки синхронного метода Delete.
- 2 перегрузки асинхронного метода DeleteAsync в соответствии с изменениями выше.
- Суть: ограничил набор параметров на каждый из методов, в соответствии с требованиями документации Вконтакте, как выходные, так и входные. 
## Требуется доработка
- Документация к методу. 
Все спорные моменты и места возникновения ошибок указаны прямо под комментариями в методе (для наглядного объяснения изменений).
## Предложение
- Ввести enum типа авторизации, что будет хранится в объекте api(_vk). 
Так каждый метод сможет обойти постоянное сравнение по null каждого спорного параметра и перейти непосредственно к установке конкретных наборов параметров в соответствии с типом авторизации. 
### Предположительные типы enum:
- CommunityAccessKey - ключ сообщества.
- UserAccessKey - пользовательский ключ.
- ServiceAccessKey - сервисный ключ.
- MixedAccessKey - смешанный ключ(Сложно *не додумал*, но предположительно позволяет переключаться между несколькими ключами путём переавторизации, как триггер можно использовать свойство set() enum авторизации внутри объекта api(_vk)).
(Определяется тип авторизации автоматически, в зависимости от параметров по которым проходит авторизация).
##### Выполнено тестов:
1. С ключом доступа сообщества [+] .
2. С ключом доступа пользователя [-] .

##### Внимание! Pull Request'ы с непройденными тестами не принимаются 
