### PR TITLE
Недокументированные VK API типы размеров фото во вложениях

### DIFF
--- a/VkNet.Tests/Enum/StringEnums/StringEnumTests.cs
+++ b/VkNet.Tests/Enum/StringEnums/StringEnumTests.cs
@@ -660,6 +660,30 @@ public class StringEnumTests
 		Utilities.Deserialize<PhotoSizeType>("w")
 			.Should()
 			.Be(PhotoSizeType.W);
+
+		Utilities.Deserialize<PhotoSizeType>("max")
+			.Should()
+			.Be(PhotoSizeType.Max);
+
+		Utilities.Deserialize<PhotoSizeType>("a")
+			.Should()
+			.Be(PhotoSizeType.A);
+
+		Utilities.Deserialize<PhotoSizeType>("b")
+			.Should()
+			.Be(PhotoSizeType.B);
+
+		Utilities.Deserialize<PhotoSizeType>("c")
+			.Should()
+			.Be(PhotoSizeType.C);
+
+		Utilities.Deserialize<PhotoSizeType>("d")
+			.Should()
+			.Be(PhotoSizeType.D);
+
+		Utilities.Deserialize<PhotoSizeType>("e")
+			.Should()
+			.Be(PhotoSizeType.E);
 	}
 
 	[Fact]

--- a/VkNet/Enums/StringEnums/PhotoSizeType.cs
+++ b/VkNet/Enums/StringEnums/PhotoSizeType.cs
@@ -80,6 +80,36 @@ public enum PhotoSizeType
 	/// <summary>
 	///
 	/// </summary>
+	Max,
+
+	/// <summary>
+	///
+	/// </summary>
+	A,
+
+	/// <summary>
+	///
+	/// </summary>
+	B,
+
+	/// <summary>
+	///
+	/// </summary>
+	C,
+
+	/// <summary>
+	///
+	/// </summary>
+	D,
+
+	/// <summary>
+	///
+	/// </summary>
+	E,
+
+	/// <summary>
+	///
+	/// </summary>
 	K,
 
 	/// <summary>


### PR DESCRIPTION
Получил от ВК такое описание ссылки во вложении к посту на стене
<details>
  <summary>JSON</summary>
  
  ```javascript
  {
  "type": "link",
  "link": {
    "url": "https://www.kommersant.ru/gallery/3318713",
    "caption": "www.kommersant.ru",
    "is_favorite": false,
    "photo": {
      "album_id": -28,
      "date": 1686053275,
      "id": 457446401,
      "owner_id": 2000018532,
      "sizes": [
        {
          "height": 544,
          "type": "max",
          "width": 817,
          "url": "https://sun9-26.userapi.com/Odn9IsoIaaSzDc8_7jcuQtipi2BdhTTyAmcHFg/rpiOY5nCiFE.jpg"
        },
        {
          "height": 365,
          "type": "o",
          "width": 817,
          "url": "https://sun9-26.userapi.com/b8_Q3jShYmG2EfGbekmMazNAeb4YAfviONcQDQ/BeO7dr2Cvlg.jpg"
        },
        {
          "height": 179,
          "type": "b",
          "width": 400,
          "url": "https://sun9-71.userapi.com/PtABv-SGo3z-d4T5lFpWOSpjf7aD-x5Pt_hCww/c_5K5CzkcOw.jpg"
        },
        {
          "height": 480,
          "type": "k",
          "width": 1074,
          "url": "https://sun9-14.userapi.com/impg/49hu28aUwgnlicPPf-Wu3ck3XfgRid5AAPDXsQ/pEem6kggxmc.jpg?size\u003d1074x480\u0026quality\u003d96\u0026sign\u003db1abe13339cb21ed4f3db9b8f1ec018d\u0026c_uniq_tag\u003d9giQHP4NoyrwV7WfTuCE-fJh6hE9UIpUDFVrq7lS4O0\u0026type\u003dshare"
        },
        {
          "height": 89,
          "type": "a",
          "width": 200,
          "url": "https://sun9-58.userapi.com/0PD_jXSuftP8WPbmB51zL201AyoUB90nUaHtKw/mivQr_a1GKw.jpg"
        },
        {
          "height": 240,
          "type": "l",
          "width": 537,
          "url": "https://sun9-14.userapi.com/impg/49hu28aUwgnlicPPf-Wu3ck3XfgRid5AAPDXsQ/pEem6kggxmc.jpg?size\u003d537x240\u0026quality\u003d96\u0026sign\u003d384ca050fd7876482bdd8ba0ced47c89\u0026c_uniq_tag\u003dJAw43xfCJaY8arVSMGjmrh4TgIrvWZKGF980enEtoIQ\u0026type\u003dshare"
        },
        {
          "height": 200,
          "type": "c",
          "width": 200,
          "url": "https://sun9-78.userapi.com/x0AXxLQzA6NVE10aG5ZNj2EpG5oWQlix6bVwEQ/8kos0phXA4c.jpg"
        },
        {
          "height": 100,
          "type": "d",
          "width": 100,
          "url": "https://sun9-7.userapi.com/3nvSm8W9zV1bh8S6vJMF15VlCikigL3vDvqd2Q/i3xaQryGlaY.jpg"
        },
        {
          "height": 50,
          "type": "e",
          "width": 50,
          "url": "https://sun9-42.userapi.com/OiG0dtZmqXqo3laGIYO7RXte2zLaci61tw2CAA/WFZpEsnoS_Y.jpg"
        }
      ],
      "text": "",
      "user_id": 100,
      "has_tags": false
    },
    "title": "Мировой Пушкин",
    "target": "internal"
  }
}
  ```
  
</details>

Библиотека не смогла десериализовать, потому что нет нужных членов в PhotoSizeType. 
В Справочнике API ничего не говорится об этих типах, так же как и о Temp, например, который уже добавлен в этот Enum.

## Список изменений
- Добавлены типы размеров фотографий A, B, C, D, E, Max
