### PR TITLE
Добавить обобщение для BotsLongPollHistoryResponse и метод GroupLongPoolHelpers.GetGroupUpdatesAndErrors

### DIFF
--- a/VkNet/Model/BotsLongPollHistoryResponse.cs
+++ b/VkNet/Model/BotsLongPollHistoryResponse.cs
@@ -6,10 +6,14 @@ using VkNet.Utils.JsonConverter;
 namespace VkNet.Model;
 
 /// <summary>
-/// Обновление в событиях группы
+/// Обновление в событиях группы.
+/// <br/>
+/// В обобщении можно указать тип JObject для того, чтобы избежать ошибок при десериализации.
+/// <br/>
+/// После чего можно воспользоваться методом GroupLongPoolHelpers.GetGroupUpdatesAndErrors. Он вернёт ошибки, если таковые имеются, но не бросит исключений.
 /// </summary>
 [Serializable]
-public class BotsLongPollHistoryResponse
+public class BotsLongPollHistoryResponse<TGroupUpdate>
 {
 	/// <summary>
 	/// Номер последнего события, начиная с которого нужно получать данные;
@@ -19,5 +23,11 @@ public class BotsLongPollHistoryResponse
 	/// <summary>
 	/// Обновления группы
 	/// </summary>
-	public List<GroupUpdate> Updates { get; set; }
+	public List<TGroupUpdate> Updates { get; set; }
+}
+
+/// <inheritdoc />
+[Serializable]
+public class BotsLongPollHistoryResponse : BotsLongPollHistoryResponse<GroupUpdate>
+{
 }

--- a/VkNet/Utils/GroupLongPoolHelpers.cs
+++ b/VkNet/Utils/GroupLongPoolHelpers.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using VkNet.Model;
+
+namespace VkNet.Utils;
+
+/// <summary>
+/// Методы для обработки событий лонгпула у сообществ.
+/// </summary>
+public static class GroupLongPoolHelpers
+{
+	/// <summary>
+	/// Метод для получения обновлений группы из массива JObject, который не бросает исключений, но вместе с обновлениями возвращает ошибки при десериализации, если таковые имеются.
+	/// </summary>
+	/// <param name="jObjectUpdates">Этот массив получается из метода api.Groups.GetBotsLongPollHistory&lt;BotsLongPollHistoryResponse&lt;JObject&gt;&gt;().Updates</param>
+	public static List<(GroupUpdate? Update, System.Exception? Exception)> GetGroupUpdatesAndErrors(List<JObject> jObjectUpdates)
+	{
+		var updates = new List<(GroupUpdate? Update, System.Exception? Exception)>();
+
+		foreach (var jObjectUpdate in jObjectUpdates)
+		{
+			try
+			{
+				var update = jObjectUpdate.ToObject<GroupUpdate>();
+				updates.Add((Update: update, Exception: null));
+			}
+			catch (System.Exception ex)
+			{
+				updates.Add((Update: null, Exception: ex));
+			}
+		}
+
+		return updates;
+	}
+}


### PR DESCRIPTION
В GroupLongPoolHelpers ещё можно добавить методов для подписки на события лонгпула. Хотя сомневаюсь, что статичного класса будет достаточно. 