### PR TITLE
Deprecate MessagesSendParams.Title

### DIFF
--- a/VkNet/Model/RequestParams/Messages/MessagesSendParams.cs
+++ b/VkNet/Model/RequestParams/Messages/MessagesSendParams.cs
@@ -21,6 +21,7 @@ public class MessagesSendParams
 	/// Заголовок сообщения(выделется жирным)
 	/// </summary>
 	[JsonProperty("title")]
+	[Obsolete("Свойство официально не поддерживается и может не отображаться в чате.")]
 	public string Title { get; set; }
 
 	/// <summary>


### PR DESCRIPTION
This property is officially unsupported since at least 2015 (https://sohabr.net/habr/post/249365/) and is currently not shown in mobile applications. In web version it behaves inconsistently (i.e., it may not show at all or disappear after some time).
