### PR TITLE
Исправление заполнения User.IsDeactivated для активного пользователя

### DIFF
--- a/VkNet.Tests/Categories/Users/UserGetTests.cs
+++ b/VkNet.Tests/Categories/Users/UserGetTests.cs
@@ -58,4 +58,30 @@ public class UserGetTests : CategoryBaseTest
 		user.Military.Should()
 			.NotBeNullOrEmpty();
 	}
+
+	[Fact]
+	public void Get_ActiveUser()
+	{
+		Url = "https://api.vk.com/method/users.get";
+		ReadCategoryJsonPath(nameof(Get_ActiveUser));
+
+		var users = Api.Users.Get(new List<long>
+		{
+			1
+		});
+
+		users.Should()
+			.NotBeNull();
+
+		var user = users.FirstOrDefault();
+
+		user.Should()
+			.NotBeNull();
+
+		user.Deactivated.Should()
+			.Be(Deactivated.Activated);
+
+		user.IsDeactivated.Should()
+			.BeFalse();
+	}
 }

--- a/VkNet.Tests/TestData/Categories/Users/Get_ActiveUser.json
+++ b/VkNet.Tests/TestData/Categories/Users/Get_ActiveUser.json
@@ -1,0 +1,11 @@
+{
+  "response": [
+	{
+	  "id": 1,
+	  "first_name": "Павел",
+	  "last_name": "Дуров",
+	  "can_access_closed": true,
+	  "is_closed": false
+	}
+  ]
+}

--- a/VkNet/Utils/JsonConverter/UserJsonConverter.cs
+++ b/VkNet/Utils/JsonConverter/UserJsonConverter.cs
@@ -225,7 +225,8 @@ public class UserJsonConverter : JsonConverter<User>
 					.ToString())
 		};
 
-		user.IsDeactivated = user.Deactivated is not null;
+		user.IsDeactivated = user.Deactivated is not null
+			and not Deactivated.Activated;
 
 		if (response["name"] is not null)
 		{


### PR DESCRIPTION
У меня повторилась ошибка #703 и на 1.78, и на последней (1.79.0-alpha-124) версии, решил исправить.

 ## Список изменений
 * Исправлено заполнение User.IsDeactivated для активного пользователя (при Deactivated.Activated)

